### PR TITLE
Add Yar for session management and flash notifications #patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-frontend",
-  "version": "0.33.2",
+  "version": "0.33.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-frontend",
-  "version": "0.33.2",
+  "version": "0.33.4",
   "description": "SFD Frontend",
   "sideEffects": false,
   "main": ".server/index.js",

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -141,6 +141,11 @@ export const serverConfig = {
           default: 'session',
           env: 'SESSION_CACHE_NAME'
         },
+        segment: {
+          doc: 'The cache segment.',
+          format: String,
+          default: 'session'
+        },
         ttl: {
           doc: 'server side session cache ttl',
           format: Number,

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -4,6 +4,7 @@ import { secureContext } from './secure-context/secure-context.js'
 import { requestTracing } from './request-tracing.js'
 import { router } from './router.js'
 import { pulse } from './pulse.js'
+import { session } from './session.js'
 
 export const plugins = [
   requestLogger,
@@ -11,5 +12,6 @@ export const plugins = [
   secureContext,
   pulse,
   vision,
-  router
+  router,
+  session
 ]

--- a/src/plugins/session.js
+++ b/src/plugins/session.js
@@ -1,0 +1,19 @@
+import Yar from '@hapi/yar'
+import { config } from '../config/index.js'
+
+export const session = {
+  plugin: Yar,
+  options: {
+    storeBlank: false,
+    maxCookieSize: 0,
+    cache: {
+      cache: config.get('server.session.cache.name'),
+      segment: `${config.get('server.session.cache.segment')}-temp`
+    },
+    cookieOptions: {
+      password: config.get('server.session.cookie.password'),
+      isSecure: !config.get('server.isDevelopment'),
+      isSameSite: 'Lax'
+    }
+  }
+}

--- a/src/utils/notifications/flash-notification.js
+++ b/src/utils/notifications/flash-notification.js
@@ -1,0 +1,23 @@
+/**
+ * Creates a flash notification using yar
+ * @module flashNotification
+ */
+
+/**
+ * This function creates a flash notification using yar
+ * It uses the title and text provided to create the notification defaulting to Updated and Changes made
+ *
+ * @param {object} yar - The Hapi `request.yar` session manager
+ * @param {string} [title='Updated'] - title for the notification
+ * @param {string} [text='Changes made'] - text for the notification
+ */
+const flashNotification = (yar, title = 'Updated', text = 'Changes made') => {
+  yar.flash('notification', {
+    title,
+    text
+  })
+}
+
+export {
+  flashNotification
+}

--- a/src/utils/session/set-session-data.js
+++ b/src/utils/session/set-session-data.js
@@ -1,0 +1,34 @@
+/**
+ * Takes the data from a request and sets it on the session
+ * @module setSessionData
+ */
+
+/**
+ * Takes the data from a request and sets it on the session
+ *
+ * Using the key provided this function will fetch the current session data already set on the state.
+ * With that data it will then update the session with the data provided. This uses the value
+ * provided as the key to update the session data.
+ *
+ * It returns the newly updated session object to be used.
+ *
+ * @param {object} data - The data from the form that will be set on the session
+ * @param {object} yar - The hapi `request.yar` object
+ * @param {string} key - The key to fetch the current session data
+ * @param {string} value - The object value
+ *
+ * @returns {object} - The updated session data object
+ */
+const setSessionData = (yar, key, value, data) => {
+  const sessionData = yar.get(key)
+
+  sessionData[value] = data
+
+  yar.set(key, sessionData)
+
+  return sessionData
+}
+
+export {
+  setSessionData
+}

--- a/test/unit/utils/notifications/flash-notification.test.js
+++ b/test/unit/utils/notifications/flash-notification.test.js
@@ -1,0 +1,36 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Thing under test
+import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
+
+describe('flashNotification', () => {
+  let yar
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Mock yar session manager
+    yar = {
+      flash: vi.fn()
+    }
+  })
+
+  test('returns the standard notification { title: "Updated", text: "Changes made" }', () => {
+    flashNotification(yar)
+
+    const [flashType, notification] = yar.flash.mock.calls[0]
+
+    expect(flashType).toEqual('notification')
+    expect(notification).toEqual({ title: 'Updated', text: 'Changes made' })
+  })
+
+  test('returns the overridden notification { title: "Fancy new title", text: "better text" }', () => {
+    flashNotification(yar, 'Fancy new title', 'better text')
+
+    const [flashType, notification] = yar.flash.mock.calls[0]
+
+    expect(flashType).toEqual('notification')
+    expect(notification).toEqual({ title: 'Fancy new title', text: 'better text' })
+  })
+})

--- a/test/unit/utils/session/set-session-data.test.js
+++ b/test/unit/utils/session/set-session-data.test.js
@@ -1,0 +1,73 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Thing under test
+import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
+
+describe('setSessionData', () => {
+  describe('when called with a data, key and a value', () => {
+    let data
+    let key
+    let value
+    let yar
+
+    beforeEach(() => {
+      vi.clearAllMocks()
+
+      const sessionData = {
+        businessAddressEnterData: {
+          businessName: 'Diddly Squat Farm',
+          businessAddress: {
+            address1: '10 Skirbeck Way',
+            city: 'Maidstone',
+            postcode: 'SK22 1DL',
+            country: 'United Kingdom'
+          }
+        }
+      }
+
+      // Mock yar session manager
+      yar = {
+        get: (key) => sessionData[key],
+        set: (key, value) => { sessionData[key] = value }
+      }
+
+      data = {
+        address1: 'Diddly Squat Farm',
+        city: 'Chipping Norton',
+        country: 'United Kingdom'
+      }
+
+      key = 'businessAddressEnterData'
+      value = 'businessAddress'
+    })
+
+    test('it sets the payload on the yar session object using the value', () => {
+      setSessionData(yar, key, value, data)
+
+      const result = yar.get(key)
+
+      expect(result).toEqual({
+        businessName: 'Diddly Squat Farm',
+        businessAddress: {
+          address1: 'Diddly Squat Farm',
+          city: 'Chipping Norton',
+          country: 'United Kingdom'
+        }
+      })
+    })
+
+    test('returns the updated session object', () => {
+      const result = setSessionData(yar, key, value, data)
+
+      expect(result).toEqual({
+        businessName: 'Diddly Squat Farm',
+        businessAddress: {
+          address1: 'Diddly Squat Farm',
+          city: 'Chipping Norton',
+          country: 'United Kingdom'
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces the `@hapi/yar` plugin into the service to provide support for session management and flash messaging.

Summary of changes: 

- Configured and registered Yar as a Hapi plugin

- Created setSessionData utility which retrieves existing session data using a key, updates the session with new data under a provided subkey, and stores the updated object back into the session. 

- Updated config to include support for session cache segment configuration.

These changes are needed for persisting data between requests and enabling flash notification to display to users.


# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity