### PR TITLE
Fix business email success banner content

### DIFF
--- a/src/services/business/update-business-email-change-service.js
+++ b/src/services/business/update-business-email-change-service.js
@@ -9,7 +9,7 @@ const updateBusinessEmailChangeService = async (yar) => {
 
   yar.set('businessDetails', businessDetails)
 
-  flashNotification(yar, 'Success', 'You have updated your business email')
+  flashNotification(yar, 'Success', 'You have updated your business email address')
 }
 
 export {

--- a/test/unit/services/business/update-business-email-change-service.test.js
+++ b/test/unit/services/business/update-business-email-change-service.test.js
@@ -45,7 +45,7 @@ describe('updateBusinessEmailChangeService', () => {
     test('adds a flash notification confirming the change in data', async () => {
       await updateBusinessEmailChangeService(yar)
 
-      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your business email')
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your business email address')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD-70

A content bug was spotted when you successfully update the business email address. The success banner currently says "You have updated your business email" when it should say "You have updated your business email address". This PR fixes this.

# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity