### PR TITLE
Remove unused email variable from dalConnector

### DIFF
--- a/src/auth/get-permissions.js
+++ b/src/auth/get-permissions.js
@@ -4,16 +4,16 @@ import { mapPermissions } from '../mappers/permissions-mapper.js'
 import { config } from '../../src/config/index.js'
 import { mappedData } from '../mock-data/mock-permissions.js'
 
-async function getPermissions (sbi, crn, email) {
-  const permission = config.get('featureToggle.dalConnection') ? await getFromDal(sbi, crn, email) : mappedData
+async function getPermissions (sbi, crn) {
+  const permission = config.get('featureToggle.dalConnection') ? await getFromDal(sbi, crn) : mappedData
 
   return permission
 }
 
-const getFromDal = async (sbi, crn, email) => {
+const getFromDal = async (sbi, crn) => {
   const variables = { sbi, crn }
 
-  const dalResponse = await dalConnector(permissionsQuery, variables, email)
+  const dalResponse = await dalConnector(permissionsQuery, variables)
 
   if (dalResponse.data) {
     const mappedResponse = mapPermissions(dalResponse.data)

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -37,8 +37,8 @@ const signInOidc = {
     // However, when signing in with RPA credentials, the roles only include the role name and not the permissions
     // Therefore, we need to make additional API calls to get the permissions from Siti Agri
     // These calls are authenticated using the token returned from Defra Identity
-    const { sbi, crn, email, sessionId } = profile
-    const { privileges, businessName } = await getPermissions(sbi, crn, email)
+    const { sbi, crn, sessionId } = profile
+    const { privileges, businessName } = await getPermissions(sbi, crn)
     // Store token and all useful data in the session cache
     await request.server.app.cache.set(sessionId, {
       isAuthenticated: true,

--- a/src/routes/business/example-routes.js
+++ b/src/routes/business/example-routes.js
@@ -2,7 +2,6 @@ import { constants as httpConstants } from 'node:http2'
 import { dalConnector } from '../../dal/connector.js'
 import { exampleQuery } from '../../dal/queries/example-query.js'
 
-const email = 'test.user11@defra.gov.uk'
 const variables = {
   sbi: '107591843',
   crn: '9477368292'
@@ -12,7 +11,7 @@ const exampleDalConnectionRoute = {
   method: 'GET',
   path: '/example',
   handler: async (_request, h) => {
-    const response = await dalConnector(exampleQuery, variables, email)
+    const response = await dalConnector(exampleQuery, variables)
 
     if (response.errors) {
       return h.response({

--- a/src/services/business/fetch-business-details-service.js
+++ b/src/services/business/fetch-business-details-service.js
@@ -26,9 +26,9 @@ const fetchBusinessDetailsService = async (yar, credentials) => {
 }
 
 const getFromDal = async (credentials) => {
-  const { sbi, crn, email } = credentials
+  const { sbi, crn } = credentials
 
-  const dalResponse = await dalConnector(businessDetailsQuery, { sbi, crn }, email)
+  const dalResponse = await dalConnector(businessDetailsQuery, { sbi, crn })
 
   if (dalResponse.data) {
     const mappedResponse = mapBusinessDetails(dalResponse.data)

--- a/src/services/personal/fetch-personal-details-service.js
+++ b/src/services/personal/fetch-personal-details-service.js
@@ -27,9 +27,9 @@ const fetchPersonalDetailsService = async (yar, credentials) => {
 }
 
 const getFromDal = async (credentials) => {
-  const { sbi, crn, email } = credentials
+  const { sbi, crn } = credentials
 
-  const dalResponse = await dalConnector(personalDetailsQuery, { sbi, crn }, email)
+  const dalResponse = await dalConnector(personalDetailsQuery, { sbi, crn })
 
   if (dalResponse.data) {
     const mappedResponse = mapPersonalDetails(dalResponse.data)

--- a/test/integration/narrow/routes/auth.test.js
+++ b/test/integration/narrow/routes/auth.test.js
@@ -161,8 +161,8 @@ describe('auth routes', () => {
           credentials
         }
       })
-      const { sbi, crn, email } = credentials.profile
-      expect(mockGetPermissions).toHaveBeenCalledWith(sbi, crn, email)
+      const { sbi, crn } = credentials.profile
+      expect(mockGetPermissions).toHaveBeenCalledWith(sbi, crn)
     })
 
     test('should set authentication status in session cache', async () => {

--- a/test/unit/auth/get-permissions.test.js
+++ b/test/unit/auth/get-permissions.test.js
@@ -27,7 +27,6 @@ vi.mock('../../../src/config/index.js', () => ({
 const { getPermissions } = await import('../../../src/auth/get-permissions.js')
 let sbi
 let crn
-let email
 
 describe('getPermissions', () => {
   beforeEach(() => {
@@ -35,7 +34,6 @@ describe('getPermissions', () => {
 
     sbi = '234654278765'
     crn = '987645433252'
-    email = 'farmer@test.com'
 
     mockConfigGet.mockReturnValue(true)
     mapPermissions.mockReturnValue(mappedData)
@@ -47,29 +45,29 @@ describe('getPermissions', () => {
       mockConfigGet.mockReturnValue(true)
     })
     test('should call dalConnector with getPermission parameters', async () => {
-      await getPermissions(sbi, crn, email)
-      expect(dalConnector).toHaveBeenCalledWith(permissionsQuery, { sbi, crn }, email)
+      await getPermissions(sbi, crn)
+      expect(dalConnector).toHaveBeenCalledWith(permissionsQuery, { sbi, crn })
     })
     test('should call mapPermissions when dalConnector response has data', async () => {
-      await getPermissions(sbi, crn, email)
+      await getPermissions(sbi, crn)
       expect(mapPermissions).toHaveBeenCalledWith(dalData)
     })
 
     test('should return mapped data  when dalConnector response has data', async () => {
-      const result = await getPermissions(sbi, crn, email)
+      const result = await getPermissions(sbi, crn)
       expect(result).toBe(mappedData)
     })
 
     test('should not call mapPermissions when dalConnector response has no data', async () => {
       dalConnector.mockResolvedValue({})
-      await getPermissions(sbi, crn, email)
+      await getPermissions(sbi, crn)
       expect(mapPermissions).not.toHaveBeenCalled()
     })
 
     test('should return dalConnector response when dalConnector response has no data', async () => {
       const dalResponse = { response: 'no-dal-data' }
       dalConnector.mockResolvedValue(dalResponse)
-      const result = await getPermissions(sbi, crn, email)
+      const result = await getPermissions(sbi, crn)
       expect(result).toBe(dalResponse)
     })
   })
@@ -79,12 +77,12 @@ describe('getPermissions', () => {
       mockConfigGet.mockReturnValue(false)
     })
     test('dalConnector is not called', async () => {
-      await getPermissions(sbi, crn, email)
+      await getPermissions(sbi, crn)
       expect(dalConnector).not.toHaveBeenCalled()
     })
 
     test('it correctly returns data static data source', async () => {
-      const result = await getPermissions(sbi, crn, email)
+      const result = await getPermissions(sbi, crn)
       expect(result).toMatchObject(mappedData)
     })
   })


### PR DESCRIPTION
This pull request removes an unnecessary variable.

It deletes the email variable that was previously being assigned, but never used inside the dalConnector.

Since the variable wasn't used anywhere, it and its related comments were removed to make the code cleaner and easier to maintain. 

This is a small refactoring change, no new functionality has been introduced, and no existing behaviour should be affected.

# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity