### PR TITLE
Add dynamic back link helper for selected presenters

### DIFF
--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -3,10 +3,12 @@
  * @module businessDetailsPresenter
  */
 
+import { dynamicBacklink } from '../../utils/dynamic-backlink.js'
 import { addressPresenter } from '../address-presenter.js'
 
-const businessDetailsPresenter = (data, yar) => {
+const businessDetailsPresenter = (data, yar, referer) => {
   return {
+    backLink: { href: dynamicBacklink(referer) },
     notification: yar ? yar.flash('notification')[0] : null,
     pageTitle: 'View and update your business details',
     metaDescription: 'View and change the details for your business.',

--- a/src/presenters/personal/personal-details-presenter.js
+++ b/src/presenters/personal/personal-details-presenter.js
@@ -3,11 +3,12 @@
  * @module personalDetailsPresenter
  */
 
+import { dynamicBacklink } from '../../utils/dynamic-backlink.js'
 import { addressPresenter } from '../address-presenter.js'
 
-const personalDetailsPresenter = (data, yar) => {
+const personalDetailsPresenter = (data, yar, referer) => {
   return {
-    backLink: { href: '/home' },
+    backLink: { href: dynamicBacklink(referer) },
     notification: yar ? yar.flash('notification')[0] : null,
     pageTitle: 'View and update your personal details',
     metaDescription: 'View and update your personal details.',

--- a/src/routes/business/business-details-routes.js
+++ b/src/routes/business/business-details-routes.js
@@ -8,9 +8,9 @@ const getBusinessDetails = {
     auth: { scope: ['BUSINESS_DETAILS:FULL_PERMISSION'] }
   },
   handler: async (request, h) => {
-    const { yar, auth } = request
+    const { yar, auth, headers } = request
     const businessDetails = await fetchBusinessDetailsService(yar, auth.credentials)
-    const pageData = businessDetailsPresenter(businessDetails, yar)
+    const pageData = businessDetailsPresenter(businessDetails, yar, headers.referer)
 
     return h.view('business/business-details.njk', pageData)
   }

--- a/src/routes/cookies-routes.js
+++ b/src/routes/cookies-routes.js
@@ -1,10 +1,13 @@
+import { dynamicBacklink } from '../utils/dynamic-backlink.js'
+
 export const cookies = {
   method: 'GET',
   path: '/cookies',
-  handler: (_request, h) => {
+  handler: (request, h) => {
     return h.view('cookies', {
       pageTitle: 'Cookies',
-      heading: 'How we use cookies to store information about how you use this service.'
+      heading: 'How we use cookies to store information about how you use this service.',
+      backLink: { href: dynamicBacklink(request.headers.referer) }
     })
   }
 }

--- a/src/routes/footer/accessibility-statement-routes.js
+++ b/src/routes/footer/accessibility-statement-routes.js
@@ -1,12 +1,13 @@
+import { dynamicBacklink } from '../../utils/dynamic-backlink.js'
+
 export const accessibilityStatement = {
   method: 'GET',
   path: '/accessibility-statement',
   handler: (request, h) => {
-    const backLink = request.headers.referer
     return h.view('footer/accessibility-statement', {
       pageTitle: 'Accessibility statement',
       heading: 'Accessibility statement',
-      backLink
+      backLink: { href: dynamicBacklink(request.headers.referer) }
     })
   }
 }

--- a/src/routes/footer/contact-us-routes.js
+++ b/src/routes/footer/contact-us-routes.js
@@ -1,10 +1,14 @@
+import { dynamicBacklink } from '../../utils/dynamic-backlink.js'
+
 export const contactUs = {
   method: 'GET',
   path: '/contact-help',
-  handler: (_request, h) => {
+  handler: (request, h) => {
+      console.log('🚀 ~ request.headers.referer:', request.headers.referer)
     return h.view('footer/contact-help', {
       pageTitle: 'Contact us for help',
-      heading: 'How to contact this service if you need help.'
+      heading: 'How to contact this service if you need help.',
+      backLink: { href: dynamicBacklink(request.headers.referer) }
     })
   }
 }

--- a/src/routes/personal/personal-details-routes.js
+++ b/src/routes/personal/personal-details-routes.js
@@ -5,9 +5,9 @@ const getPersonalDetails = {
   method: 'GET',
   path: '/personal-details',
   handler: async (request, h) => {
-    const { yar, auth } = request
+    const { yar, auth, headers } = request
     const personalDetails = await fetchPersonalDetailsService(yar, auth.credentials)
-    const pageData = personalDetailsPresenter(personalDetails, request.yar)
+    const pageData = personalDetailsPresenter(personalDetails, request.yar, headers.referer)
 
     return h.view('personal/personal-details.njk', pageData)
   }

--- a/src/utils/dynamic-backlink.js
+++ b/src/utils/dynamic-backlink.js
@@ -1,0 +1,22 @@
+/**
+ * Resolves a safe back link path from a referer URL or path.
+ * - If `referer` is a full URL, returns only the pathname.
+ * - If `referer` is already a path, returns it (ensures it starts with `/`).
+ * - If `referer` is missing or invalid, returns `/` as fallback.
+ *
+ * @param {string} referer - The referer header value or path
+ * @returns {string} Safe back link path
+ */
+const dynamicBacklink = (referer) => {
+  if (!referer) {
+    return '/'
+  }
+
+  try {
+    return new URL(referer).pathname
+  } catch {
+    return referer.startsWith('/') ? referer : `/${referer}`
+  }
+}
+
+export { dynamicBacklink }

--- a/src/views/cookies.njk
+++ b/src/views/cookies.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block beforeContent %}
-  {{ appBackSignOutLink({ href: '/business-details'}) }}
+  {{ appBackSignOutLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/src/views/footer/accessibility-statement.njk
+++ b/src/views/footer/accessibility-statement.njk
@@ -2,7 +2,7 @@
 {% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink %}
 
 {% block beforeContent %}
-{{ appBackSignOutLink({ href: backLink }) }}
+{{ appBackSignOutLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/src/views/footer/contact-help.njk
+++ b/src/views/footer/contact-help.njk
@@ -2,7 +2,7 @@
 {% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink %}
 
 {% block beforeContent %}
-{{ appBackSignOutLink({ href: '/business-details'}) }}
+{{ appBackSignOutLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -7,12 +7,14 @@ import { businessDetailsPresenter } from '../../../../src/presenters/business/bu
 describe('businessDetailsPresenter', () => {
   let yar
   let data
+  let referer
 
   beforeEach(async () => {
     vi.clearAllMocks()
     vi.resetModules() // vi is weird about clearing modules after each test, you must import AFTER calling reset
     const { mappedData } = await import('../../../mocks/mock-business-details.js')
     data = mappedData
+    referer = 'https://example.com/home'
 
     // Mock yar session manager
     yar = {
@@ -22,9 +24,10 @@ describe('businessDetailsPresenter', () => {
 
   describe('when provided with business details data', () => {
     test('it correctly presents the data', () => {
-      const result = businessDetailsPresenter(data, yar)
+      const result = businessDetailsPresenter(data, yar, referer)
 
       expect(result).toEqual({
+        backLink: { href: '/home' },
         notification: { title: 'Update', text: 'Business details updated successfully' },
         pageTitle: 'View and update your business details',
         metaDescription: 'View and change the details for your business.',
@@ -57,7 +60,7 @@ describe('businessDetailsPresenter', () => {
     describe('when the landline property is missing', () => {
       test('it should return the text "Not added', () => {
         data.contact.landline = null
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.businessTelephone).toEqual('Not added')
       })
@@ -67,7 +70,7 @@ describe('businessDetailsPresenter', () => {
   describe('the "businessMobile" property', () => {
     describe('when the businessMobile property is missing', () => {
       test('it should return the text "Not added', () => {
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.businessMobile).toEqual('Not added')
       })
@@ -78,7 +81,7 @@ describe('businessDetailsPresenter', () => {
     describe('when the property is null', () => {
       test('it should return null', () => {
         data.info.vat = null
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.vatNumber).toEqual(null)
       })
@@ -89,7 +92,7 @@ describe('businessDetailsPresenter', () => {
     describe('when the property is empty', () => {
       test('it should return empty array', () => {
         data.info.countyParishHoldingNumbers = []
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.countyParishHoldingNumbers).toEqual([])
       })
@@ -100,7 +103,7 @@ describe('businessDetailsPresenter', () => {
     describe('when the property is null', () => {
       test('it should return null', () => {
         data.info.traderNumber = null
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.tradeNumber).toEqual(null)
       })
@@ -111,7 +114,7 @@ describe('businessDetailsPresenter', () => {
     describe('when the property is null', () => {
       test('it should return null', () => {
         data.info.vendorNumber = null
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.vendorRegistrationNumber).toEqual(null)
       })
@@ -122,7 +125,7 @@ describe('businessDetailsPresenter', () => {
     describe('when yar is falsey', () => {
       test('it should return null', () => {
         yar = null
-        const result = businessDetailsPresenter(data, yar)
+        const result = businessDetailsPresenter(data, yar, referer)
 
         expect(result.notification).toEqual(null)
       })

--- a/test/unit/presenters/personal/personal-details-presenter.test.js
+++ b/test/unit/presenters/personal/personal-details-presenter.test.js
@@ -13,6 +13,7 @@ import { mappedData as originalData } from '../../../mocks/mock-personal-details
 describe('personalDetailsPresenter', () => {
   let yar
   let data
+  let referer
 
   vi.mock('../../../../src/presenters/address-presenter.js', () => ({
     addressPresenter: {
@@ -33,6 +34,7 @@ describe('personalDetailsPresenter', () => {
 
     // Deep clone the data to avoid mutation across tests
     data = JSON.parse(JSON.stringify(originalData))
+    referer = 'https://example.com/home'
 
     // Mock yar session manager
     yar = {
@@ -42,7 +44,7 @@ describe('personalDetailsPresenter', () => {
 
   describe('when provided with personal details data', () => {
     test('it correctly presents the data', () => {
-      const result = personalDetailsPresenter(data, yar)
+      const result = personalDetailsPresenter(data, yar, referer)
 
       expect(result).toEqual({
         backLink: { href: '/home' },
@@ -64,7 +66,7 @@ describe('personalDetailsPresenter', () => {
     test('returns "Not added" if telephone is missing', () => {
       data.contact.telephone = null
 
-      const result = personalDetailsPresenter(data, yar)
+      const result = personalDetailsPresenter(data, yar, referer)
 
       expect(result.personalTelephone).toBe('Not added')
     })
@@ -74,7 +76,7 @@ describe('personalDetailsPresenter', () => {
     test('returns "Not added" if mobile is missing', () => {
       data.contact.mobile = null
 
-      const result = personalDetailsPresenter(data, yar)
+      const result = personalDetailsPresenter(data, yar, referer)
 
       expect(result.personalMobile).toBe('Not added')
     })
@@ -82,7 +84,7 @@ describe('personalDetailsPresenter', () => {
 
   describe('the "notification" property', () => {
     test('returns null if yar is falsy', () => {
-      const result = personalDetailsPresenter(data, null)
+      const result = personalDetailsPresenter(data, null, referer)
 
       expect(result.notification).toBe(null)
     })
@@ -90,7 +92,7 @@ describe('personalDetailsPresenter', () => {
 
   describe('the "fullName" property', () => {
     test('returns a formatted full name', () => {
-      const result = personalDetailsPresenter(data, yar)
+      const result = personalDetailsPresenter(data, yar, referer)
 
       expect(result.fullName).toBe('John M Doe')
     })
@@ -99,7 +101,7 @@ describe('personalDetailsPresenter', () => {
       test('returns a formatted full name without the middle name', () => {
         data.info.fullName.middle = null
 
-        const result = personalDetailsPresenter(data, yar)
+        const result = personalDetailsPresenter(data, yar, referer)
 
         expect(result.fullName).toBe('John Doe')
       })

--- a/test/unit/routes/business/business-details-routes.test.js
+++ b/test/unit/routes/business/business-details-routes.test.js
@@ -45,6 +45,9 @@ describe('business details', () => {
               crn: '987654321',
               email: 'test@example.com'
             }
+          },
+          headers: {
+            referer: 'https://example.com/home'
           }
         }
 
@@ -89,6 +92,7 @@ const getMockData = () => {
 
 const getPageData = () => {
   return {
+    backlink: { href: 'https://example.com/home' },
     businessName: 'Agile Farm Ltd',
     businessAddress: {
       address1: '10 Skirbeck Way',

--- a/test/unit/routes/personal/personal-details-routes.test.js
+++ b/test/unit/routes/personal/personal-details-routes.test.js
@@ -44,6 +44,9 @@ describe('personal details', () => {
               crn: '987654321',
               email: 'test@example.com'
             }
+          },
+          headers: {
+            referer: 'https://example.com/home'
           }
         }
 
@@ -55,7 +58,7 @@ describe('personal details', () => {
         await getPersonalDetails.handler(request, h)
 
         expect(fetchPersonalDetailsService).toHaveBeenCalledWith(request.yar, request.auth.credentials)
-        expect(personalDetailsPresenter).toHaveBeenCalledWith(mockData, request.yar)
+        expect(personalDetailsPresenter).toHaveBeenCalledWith(mockData, request.yar, 'https://example.com/home')
         expect(h.view).toHaveBeenCalledWith('personal/personal-details.njk', pageData)
       })
     })
@@ -82,6 +85,7 @@ const getMockData = () => ({
 })
 
 const getPageData = () => ({
+  backlink: { href: 'https://example.com/home' },
   pageTitle: 'View and update your personal details',
   metaDescription: 'View and update your personal details.',
   address: [

--- a/test/unit/utils/dynamic-backlink.test.js
+++ b/test/unit/utils/dynamic-backlink.test.js
@@ -1,0 +1,34 @@
+// Test framework dependencies
+import { describe, test, expect } from 'vitest'
+
+// Thing under test
+import { dynamicBacklink } from '../../../src/utils/dynamic-backlink.js'
+
+describe('dynamicBackLink', () => {
+  test('returns / if referer is undefined', () => {
+    expect(dynamicBacklink(undefined)).toBe('/')
+    expect(dynamicBacklink(null)).toBe('/')
+  })
+
+  test('returns only pathname if referer is a full URL', () => {
+    expect(dynamicBacklink('https://example.com/business-address-check')).toBe('/business-address-check')
+    expect(dynamicBacklink('http://localhost:3000/test/path')).toBe('/test/path')
+  })
+
+  test('returns the path as-is if referer is already a path starting with /', () => {
+    expect(dynamicBacklink('/my-page')).toBe('/my-page')
+    expect(dynamicBacklink('/another/path')).toBe('/another/path')
+  })
+
+  test('prepends / if referer is a relative path not starting with /', () => {
+    expect(dynamicBacklink('some-page')).toBe('/some-page')
+    expect(dynamicBacklink('another/path')).toBe('/another/path')
+  })
+
+  test('returns / if referer is an invalid URL string', () => {
+    // Invalid full URL
+    expect(dynamicBacklink('http://')).toBe('/http://')
+    // Non-URL string without leading /
+    expect(dynamicBacklink('invalid-url')).toBe('/invalid-url')
+  })
+})


### PR DESCRIPTION
This PR introduces a utility to handle dynamic back links in presenters that need them, without affecting all pages.

What’s changed

* Added dynamicBacklink function in utils/dynamic-backlink.js
* Extracts the path from a full referer URL or path.
* Falls back to / if no referer is provided.
* Updated only the presenters where back links should be dynamic to use dynamicBacklink(request.headers.referer)
* Existing hardcoded back links remain unchanged and take priority over the dynamic fallback

Why this matters

* Provides safe, dynamic back links only where needed.
* Reduces duplication of back link logic in these specific presenters.

# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity