### PR TITLE
bug/SFD2-39 Fix VAT Removal Confirmation Logic

### DIFF
--- a/src/dal/mutations/update-business-vat.js
+++ b/src/dal/mutations/update-business-vat.js
@@ -1,0 +1,12 @@
+export const updateBusinessVATMutation = `
+  mutation Mutation($input: UpdateBusinessVATInput!) {
+    updateBusinessVAT(input: $input) {
+      business {
+        info {
+          vat
+        }
+      }
+      success
+    }
+  }
+`

--- a/src/presenters/business/business-vat-remove-presenter.js
+++ b/src/presenters/business/business-vat-remove-presenter.js
@@ -1,0 +1,20 @@
+/**
+ * Formats data ready for presenting in the `/business-vat-remove` page
+ * @module businessVatRemovePresenter
+ */
+
+const businessVatRemovePresenter = (data) => {
+  return {
+    backLink: { href: '/business-details' },
+    pageTitle: 'Are you sure you want to remove your VAT registration number?',
+    metaDescription: 'Are you sure you want to remove your VAT registration number?',
+    vatNumber: data.info.vat ?? null,
+    businessName: data.info.businessName ?? null,
+    sbi: data.info.sbi ?? null,
+    userName: data.customer.fullName ?? null
+  }
+}
+
+export {
+  businessVatRemovePresenter
+}

--- a/src/routes/business/business-routes.js
+++ b/src/routes/business/business-routes.js
@@ -11,6 +11,7 @@ import { businessPhoneNumbersCheckRoutes } from './business-phone-numbers-check-
 import { businessTypeRoutes } from './business-type-change-routes.js'
 import { businessVatChangeRoutes } from './business-vat-change-routes.js'
 import { businessVatCheckRoutes } from './business-vat-check-routes.js'
+import { businessVatRemoveRoutes } from './business-vat-remove-routes.js'
 import { exampleDalConnectionRoute } from './example-routes.js'
 
 export const businessRoutes = [
@@ -27,5 +28,6 @@ export const businessRoutes = [
   ...businessTypeRoutes,
   ...businessVatChangeRoutes,
   ...businessVatCheckRoutes,
+  ...businessVatRemoveRoutes,
   exampleDalConnectionRoute
 ]

--- a/src/routes/business/business-vat-remove-routes.js
+++ b/src/routes/business/business-vat-remove-routes.js
@@ -1,0 +1,27 @@
+import { fetchBusinessDetailsService } from '../../services/business/fetch-business-details-service.js'
+import { updateBusinessVatRemoveService } from '../../services/business/update-business-vat-remove-service.js'
+import { businessVatRemovePresenter } from '../../presenters/business/business-vat-remove-presenter.js'
+
+const getBusinessVatRemove = {
+  method: 'GET',
+  path: '/business-vat-remove',
+  handler: async (request, h) => {
+    const businessDetails = await fetchBusinessDetailsService(request.yar, request.auth.credentials)
+    const pageData = businessVatRemovePresenter(businessDetails)
+    return h.view('business/business-vat-remove', pageData)
+  }
+}
+
+const postBusinessVatRemove = {
+  method: 'POST',
+  path: '/business-vat-remove',
+  handler: async (request, h) => {
+    await updateBusinessVatRemoveService(request.yar, request.auth.credentials)
+    return h.redirect('/business-details')
+  }
+}
+
+export const businessVatRemoveRoutes = [
+  getBusinessVatRemove,
+  postBusinessVatRemove
+]

--- a/src/schemas/business/business-vat-remove-schema.js
+++ b/src/schemas/business/business-vat-remove-schema.js
@@ -1,0 +1,11 @@
+import Joi from 'joi'
+
+export const businessVatRemoveSchema = Joi.object({
+  confirmRemove: Joi.string()
+    .valid('yes', 'no')
+    .required()
+    .messages({
+      'any.required': 'Select yes if you want to remove your VAT registration number',
+      'any.only': 'Select yes if you want to remove your VAT registration number'
+    })
+})

--- a/src/services/business/update-business-vat-remove-service.js
+++ b/src/services/business/update-business-vat-remove-service.js
@@ -1,10 +1,19 @@
+import { dalConnector } from '../../dal/connector.js'
+import { updateBusinessVatMutation } from '../../dal/mutations/update-business-vat.js'
 import { fetchBusinessDetailsService } from './fetch-business-details-service.js'
 import { flashNotification } from '../../utils/notifications/flash-notification.js'
 
 const updateBusinessVatRemoveService = async (yar, credentials) => {
   const businessDetails = await fetchBusinessDetailsService(yar, credentials)
+  console.log('businessDetails:::', businessDetails)
 
-  // TODO: Call the GraphQL mutation to remove the VAT number
+  const variables = { input: { vat: businessDetails.info.vat, sbi: businessDetails.info.sbi } }
+
+  const response = await dalConnector(updateBusinessVatMutation, variables)
+
+  if (response.errors) {
+    throw new Error('DAL error from mutation')
+  }
 
   businessDetails.info.vat = null
 

--- a/src/services/business/update-business-vat-remove-service.js
+++ b/src/services/business/update-business-vat-remove-service.js
@@ -1,5 +1,5 @@
 import { dalConnector } from '../../dal/connector.js'
-import { updateBusinessVatMutation } from '../../dal/mutations/update-business-vat.js'
+import { updateBusinessVATMutation } from '../../dal/mutations/update-business-vat.js'
 import { fetchBusinessDetailsService } from './fetch-business-details-service.js'
 import { flashNotification } from '../../utils/notifications/flash-notification.js'
 
@@ -9,7 +9,7 @@ const updateBusinessVatRemoveService = async (yar, credentials) => {
 
   const variables = { input: { vat: businessDetails.info.vat, sbi: businessDetails.info.sbi } }
 
-  const response = await dalConnector(updateBusinessVatMutation, variables)
+  const response = await dalConnector(updateBusinessVATMutation, variables)
 
   if (response.errors) {
     throw new Error('DAL error from mutation')

--- a/src/services/business/update-business-vat-remove-service.js
+++ b/src/services/business/update-business-vat-remove-service.js
@@ -1,0 +1,17 @@
+import { fetchBusinessDetailsService } from './fetch-business-details-service.js'
+import { flashNotification } from '../../utils/notifications/flash-notification.js'
+
+const updateBusinessVatRemoveService = async (yar, credentials) => {
+  const businessDetails = await fetchBusinessDetailsService(yar, credentials)
+
+  // TODO: Call the GraphQL mutation to remove the VAT number
+
+  businessDetails.info.vat = null
+
+  yar.set('businessDetails', businessDetails)
+  flashNotification(yar, 'Success', 'You have removed your business VAT number')
+}
+
+export {
+  updateBusinessVatRemoveService
+}

--- a/src/services/business/update-business-vat-remove-service.js
+++ b/src/services/business/update-business-vat-remove-service.js
@@ -5,7 +5,6 @@ import { flashNotification } from '../../utils/notifications/flash-notification.
 
 const updateBusinessVatRemoveService = async (yar, credentials) => {
   const businessDetails = await fetchBusinessDetailsService(yar, credentials)
-  console.log('businessDetails:::', businessDetails)
 
   const variables = { input: { vat: businessDetails.info.vat, sbi: businessDetails.info.sbi } }
 

--- a/src/services/business/update-business-vat-remove-service.js
+++ b/src/services/business/update-business-vat-remove-service.js
@@ -17,7 +17,7 @@ const updateBusinessVatRemoveService = async (yar, credentials) => {
   businessDetails.info.vat = null
 
   yar.set('businessDetails', businessDetails)
-  flashNotification(yar, 'Success', 'You have removed your business VAT number')
+  flashNotification(yar, 'Success', 'You have removed your VAT registration number')
 }
 
 export {

--- a/src/views/business/business-vat-remove.njk
+++ b/src/views/business/business-vat-remove.njk
@@ -1,0 +1,70 @@
+{% extends 'common/layout.njk' %}
+
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "common/navigation/back-sign-out-link.njk" import appBackSignOutLink %}
+{% from "common/sub-header/macro.njk" import subHeader %}
+
+{% block beforeContent %}
+  {{ subHeader(businessName=businessName, sbi=sbi, userName=userName) }}
+  {{ appBackSignOutLink(backLink) }}
+{% endblock %}
+
+{% block content %}
+  {% if errors %}
+    {{ govukErrorSummary({
+        titleText: "There is a problem",
+        errorList: [
+          {
+            text: errors.confirmRemove.text,
+            href: "#confirm-remove"
+          }
+        ]
+    }) }}
+  {% endif %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <form method="post" novalidate>
+      <input type="hidden" name="crumb" value="{{ crumb }}">
+      <div class="govuk-form-group">
+        <h1 class="govuk-heading-l">
+          {{ pageTitle }}
+        </h1>
+
+        {{ govukRadios({
+          name: "confirmRemove",
+          fieldset: {
+            legend: {
+              text: "",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--l"
+            }
+          },
+          items: [
+            {
+              value: "yes",
+              text: "Yes",
+              checked: confirmRemove === "yes"
+            },
+            {
+              value: "no",
+              text: "No",
+              checked: confirmRemove === "no"
+            }
+          ],
+          errorMessage: errors.confirmRemove and {
+            text: errors.confirmRemove.text
+          }
+        }) }}
+      </div>
+
+      {{ govukButton({
+        text: "Submit",
+        preventDoubleClick: true
+      }) }}
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/test/unit/dal/mutations/update-business-vat.test.js
+++ b/test/unit/dal/mutations/update-business-vat.test.js
@@ -1,0 +1,20 @@
+import { parse } from 'graphql'
+import { describe, test, expect } from 'vitest'
+import { updateBusinessVATMutation } from '../../../../src/dal/mutations/update-business-vat.js'
+
+describe('When the updateBusinessVATMutation is parsed', () => {
+  test('it is valid GraphQL syntax', () => {
+    expect(() => parse(updateBusinessVATMutation)).not.toThrow()
+  })
+
+  test('it contains the Mutation operation and the correct variable', () => {
+    const ast = parse(updateBusinessVATMutation)
+    const operation = ast.definitions[0]
+
+    expect(operation.operation).toBe('mutation')
+
+    const variable = operation.variableDefinitions[0]
+    expect(variable.variable.name.value).toBe('input')
+    expect(variable.type.type.name.value).toBe('UpdateBusinessVATInput')
+  })
+})

--- a/test/unit/presenters/business/business-vat-remove-presenter.test.js
+++ b/test/unit/presenters/business/business-vat-remove-presenter.test.js
@@ -1,0 +1,106 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach } from 'vitest'
+
+// Thing under test
+import { businessVatRemovePresenter } from '../../../../src/presenters/business/business-vat-remove-presenter.js'
+
+describe('businessVatRemovePresenter', () => {
+  let data
+
+  beforeEach(() => {
+    data = {
+      info: {
+        businessName: 'Agile Farm Ltd',
+        sbi: '123456789',
+        vat: 'GB123456789'
+      },
+      customer: {
+        fullName: 'Alfred Waldron'
+      }
+    }
+  })
+
+  describe('when provided with business vat remove data', () => {
+    test('it correctly presents the data', () => {
+      const result = businessVatRemovePresenter(data)
+
+      expect(result).toEqual({
+        backLink: { href: '/business-details' },
+        pageTitle: 'Are you sure you want to remove your VAT registration number?',
+        metaDescription: 'Are you sure you want to remove your VAT registration number?',
+        vatNumber: 'GB123456789',
+        businessName: 'Agile Farm Ltd',
+        sbi: '123456789',
+        userName: 'Alfred Waldron'
+      })
+    })
+  })
+
+  describe('the "businessName" property', () => {
+    describe('when the businessName property is missing', () => {
+      beforeEach(() => {
+        delete data.info.businessName
+      })
+
+      test('it should return businessName as null', () => {
+        const result = businessVatRemovePresenter(data)
+
+        expect(result.businessName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "sbi" property', () => {
+    describe('when the sbi (singleBusinessIdentifier) property is missing', () => {
+      beforeEach(() => {
+        delete data.info.sbi
+      })
+
+      test('it should return sbi as null', () => {
+        const result = businessVatRemovePresenter(data)
+
+        expect(result.sbi).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "userName" property', () => {
+    describe('when the userName property is missing', () => {
+      beforeEach(() => {
+        delete data.customer.fullName
+      })
+
+      test('it should return userName as null', () => {
+        const result = businessVatRemovePresenter(data)
+
+        expect(result.userName).toEqual(null)
+      })
+    })
+  })
+
+  describe('the "vatNumber" property', () => {
+    describe('when the vat property is missing', () => {
+      beforeEach(() => {
+        delete data.info.vat
+      })
+
+      test('it should return vatNumber as null', () => {
+        const result = businessVatRemovePresenter(data)
+
+        expect(result.vatNumber).toEqual(null)
+      })
+    })
+
+    describe('when the vat property is null', () => {
+      beforeEach(() => {
+        data.info.vat = null
+      })
+
+      test('it should return vatNumber as null', () => {
+        const result = businessVatRemovePresenter(data)
+
+        expect(result.vatNumber).toEqual(null)
+      })
+    })
+  })
+})

--- a/test/unit/routes/business/business-vat-remove-routes.test.js
+++ b/test/unit/routes/business/business-vat-remove-routes.test.js
@@ -1,0 +1,126 @@
+// Test framework dependencies
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+// Things we need to mock
+import { fetchBusinessDetailsService } from '../../../../src/services/business/fetch-business-details-service.js'
+import { updateBusinessVatRemoveService } from '../../../../src/services/business/update-business-vat-remove-service.js'
+import { businessVatRemovePresenter } from '../../../../src/presenters/business/business-vat-remove-presenter.js'
+
+// Thing under test
+import { businessVatRemoveRoutes } from '../../../../src/routes/business/business-vat-remove-routes.js'
+const [getBusinessVatRemove, postBusinessVatRemove] = businessVatRemoveRoutes
+
+// Mocks
+vi.mock('../../../../src/services/business/fetch-business-details-service.js', () => ({
+  fetchBusinessDetailsService: vi.fn()
+}))
+
+vi.mock('../../../../src/services/business/update-business-vat-remove-service.js', () => ({
+  updateBusinessVatRemoveService: vi.fn()
+}))
+
+vi.mock('../../../../src/presenters/business/business-vat-remove-presenter.js', () => ({
+  businessVatRemovePresenter: vi.fn()
+}))
+
+describe('business VAT remove', () => {
+  const request = {
+    yar: {},
+    auth: {
+      credentials: {
+        sbi: '123456789',
+        crn: '987654321',
+        email: 'test@example.com'
+      }
+    }
+  }
+  let h
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Mock yar.set for session
+    request.yar = {
+      set: vi.fn(),
+      get: vi.fn().mockReturnValue(getMockData())
+    }
+  })
+
+  describe('GET /business-vat-remove', () => {
+    describe('when a request is valid', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn().mockReturnValue({})
+        }
+
+        fetchBusinessDetailsService.mockReturnValue(getMockData())
+        businessVatRemovePresenter.mockReturnValue(getPageData())
+      })
+
+      test('should have the correct method and path', () => {
+        expect(getBusinessVatRemove.method).toBe('GET')
+        expect(getBusinessVatRemove.path).toBe('/business-vat-remove')
+      })
+
+      test('it fetches the data from the session', async () => {
+        await getBusinessVatRemove.handler(request, h)
+
+        expect(fetchBusinessDetailsService).toHaveBeenCalledWith(request.yar, request.auth.credentials)
+      })
+
+      test('should render business-vat-remove view with page data', async () => {
+        await getBusinessVatRemove.handler(request, h)
+
+        expect(h.view).toHaveBeenCalledWith('business/business-vat-remove', getPageData())
+      })
+    })
+  })
+
+  describe('POST /business-vat-remove', () => {
+    beforeEach(() => {
+      h = {
+        redirect: vi.fn(() => h)
+      }
+    })
+
+    describe('when a request succeeds', () => {
+      test('it redirects to the /business-details page', async () => {
+        await postBusinessVatRemove.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/business-details')
+      })
+
+      test('calls the update service', async () => {
+        await postBusinessVatRemove.handler(request, h)
+
+        expect(updateBusinessVatRemoveService).toHaveBeenCalledWith(request.yar, request.auth.credentials)
+      })
+    })
+  })
+})
+
+const getMockData = () => {
+  return {
+    info: {
+      businessName: 'Agile Farm Ltd',
+      sbi: '123456789',
+      vat: 'GB123456789'
+    },
+    customer: {
+      fullName: 'Alfred Waldron'
+    }
+  }
+}
+
+const getPageData = () => {
+  return {
+    backLink: { href: '/business-details' },
+    pageTitle: 'Are you sure you want to remove your VAT registration number?',
+    metaDescription: 'Are you sure you want to remove your VAT registration number?',
+    vatNumber: 'GB123456789',
+    businessName: 'Agile Farm Ltd',
+    sbi: '123456789',
+    userName: 'Alfred Waldron',
+    confirmRemove: null
+  }
+}

--- a/test/unit/routes/business/business-vat-remove-routes.test.js
+++ b/test/unit/routes/business/business-vat-remove-routes.test.js
@@ -84,16 +84,56 @@ describe('business VAT remove', () => {
     })
 
     describe('when a request succeeds', () => {
+      beforeEach(() => {
+        request.payload = { confirmRemove: 'yes' }
+      })
+
       test('it redirects to the /business-details page', async () => {
-        await postBusinessVatRemove.handler(request, h)
+        await postBusinessVatRemove.options.handler(request, h)
 
         expect(h.redirect).toHaveBeenCalledWith('/business-details')
       })
 
-      test('calls the update service', async () => {
-        await postBusinessVatRemove.handler(request, h)
+      test('calls the update service with confirmRemove parameter', async () => {
+        await postBusinessVatRemove.options.handler(request, h)
 
         expect(updateBusinessVatRemoveService).toHaveBeenCalledWith(request.yar, request.auth.credentials)
+      })
+    })
+
+    describe('when user selects "no"', () => {
+      beforeEach(() => {
+        request.payload = { confirmRemove: 'no' }
+      })
+
+      test('it redirects to the /business-details page', async () => {
+        await postBusinessVatRemove.options.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/business-details')
+      })
+
+      test('does not call the update service', async () => {
+        await postBusinessVatRemove.options.handler(request, h)
+
+        expect(updateBusinessVatRemoveService).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when validation fails', () => {
+      beforeEach(() => {
+        h = {
+          view: vi.fn().mockReturnValue({
+            code: vi.fn().mockReturnThis(),
+            takeover: vi.fn().mockReturnThis()
+          })
+        }
+        request.payload = { confirmRemove: 'maybe' } // Invalid value
+      })
+
+      test('should have validation options', () => {
+        expect(postBusinessVatRemove.options).toBeDefined()
+        expect(postBusinessVatRemove.options.validate).toBeDefined()
+        expect(postBusinessVatRemove.options.validate.payload).toBeDefined()
       })
     })
   })
@@ -120,7 +160,6 @@ const getPageData = () => {
     vatNumber: 'GB123456789',
     businessName: 'Agile Farm Ltd',
     sbi: '123456789',
-    userName: 'Alfred Waldron',
-    confirmRemove: null
+    userName: 'Alfred Waldron'
   }
 }

--- a/test/unit/services/business/update-business-vat-remove-service.test.js
+++ b/test/unit/services/business/update-business-vat-remove-service.test.js
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach, vi } from 'vitest'
 import { fetchBusinessDetailsService } from '../../../../src/services/business/fetch-business-details-service'
 import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
 import { dalConnector } from '../../../../src/dal/connector.js'
-import { updateBusinessVatMutation } from '../../../../src/dal/mutations/update-business-vat.js'
+import { updateBusinessVATMutation } from '../../../../src/dal/mutations/update-business-vat.js'
 
 // Test helpers
 import { mappedData } from '../../../mocks/mock-business-details.js'
@@ -63,7 +63,7 @@ describe('updateBusinessVatRemoveService', () => {
     test('it calls dalConnector with correct mutation and variable', async () => {
       await updateBusinessVatRemoveService(yar, credentials)
 
-      expect(dalConnector).toHaveBeenCalledWith(updateBusinessVatMutation, {
+      expect(dalConnector).toHaveBeenCalledWith(updateBusinessVATMutation, {
         input: {
           vat: 'GB123456789',
           sbi: '107183280'

--- a/test/unit/services/business/update-business-vat-remove-service.test.js
+++ b/test/unit/services/business/update-business-vat-remove-service.test.js
@@ -74,7 +74,7 @@ describe('updateBusinessVatRemoveService', () => {
     test('adds a flash notification confirming the VAT removal', async () => {
       await updateBusinessVatRemoveService(yar, credentials)
 
-      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have removed your business VAT number')
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have removed your VAT registration number')
     })
   })
 

--- a/test/unit/services/business/update-business-vat-remove-service.test.js
+++ b/test/unit/services/business/update-business-vat-remove-service.test.js
@@ -35,6 +35,7 @@ vi.mock('../../../../src/dal/connector.js', () => ({
     }
   })
 }))
+
 describe('updateBusinessVatRemoveService', () => {
   let yar
   let credentials
@@ -51,7 +52,7 @@ describe('updateBusinessVatRemoveService', () => {
     credentials = { sbi: '123456789', crn: '987654321' }
   })
 
-  describe('when called', () => {
+  describe('when confirmRemove is "yes"', () => {
     test('it correctly saves the data to the session with VAT set to null', async () => {
       await updateBusinessVatRemoveService(yar, credentials)
 

--- a/test/unit/services/business/update-business-vat-remove-service.test.js
+++ b/test/unit/services/business/update-business-vat-remove-service.test.js
@@ -1,0 +1,54 @@
+// Test framework dependencies
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// Things we need to mock
+import { fetchBusinessDetailsService } from '../../../../src/services/business/fetch-business-details-service'
+import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
+
+// Test helpers
+import { mappedData } from '../../../mocks/mock-business-details.js'
+
+// Thing under test
+import { updateBusinessVatRemoveService } from '../../../../src/services/business/update-business-vat-remove-service'
+
+// Mocks
+vi.mock('../../../../src/services/business/fetch-business-details-service', () => ({
+  fetchBusinessDetailsService: vi.fn()
+}))
+
+vi.mock('../../../../src/utils/notifications/flash-notification.js', () => ({
+  flashNotification: vi.fn()
+}))
+
+describe('updateBusinessVatRemoveService', () => {
+  let yar
+  let credentials
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mappedData.info.vat = 'GB123456789'
+    fetchBusinessDetailsService.mockReturnValue(mappedData)
+
+    yar = {
+      set: vi.fn().mockReturnValue()
+    }
+    credentials = { sbi: '123456789', crn: '987654321', email: 'test@example.com' }
+  })
+
+  describe('when called', () => {
+    test('it correctly saves the data to the session with VAT set to null', async () => {
+      await updateBusinessVatRemoveService(yar, credentials)
+
+      expect(fetchBusinessDetailsService).toHaveBeenCalledWith(yar, credentials)
+      expect(mappedData.info.vat).toBeNull()
+      expect(yar.set).toHaveBeenCalledWith('businessDetails', mappedData)
+    })
+
+    test('adds a flash notification confirming the VAT removal', async () => {
+      await updateBusinessVatRemoveService(yar, credentials)
+
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have removed your business VAT number')
+    })
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-39

The VAT removal page was missing proper form validation, which caused the VAT removal service to always execute regardless of the user's input.

# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity