### PR TITLE
SFD2-39 Text When No VAT Number

### DIFF
--- a/src/presenters/business/business-details-presenter.js
+++ b/src/presenters/business/business-details-presenter.js
@@ -20,7 +20,7 @@ const businessDetailsPresenter = (data, yar) => {
     businessPhoneAction: data.contact.landline || data.contact.mobile ? 'Change' : 'Add',
     businessEmail: data.contact.email,
     sbi: data.info.sbi,
-    vatNumber: data.info.vat ?? 'No number added',
+    vatNumber: data.info.vat ?? 'Number not added',
     hasVatNumber: data.info.vat ?? false,
     vatRemoveLink: '/business-vat-registration-remove',
     vatChangeLink: '/business-vat-registration-number-change',

--- a/src/views/business/business-details.njk
+++ b/src/views/business/business-details.njk
@@ -137,12 +137,12 @@
           <dt class="govuk-summary-list__key">
             VAT registration number
           </dt>
+         {# Logic to display the correct link actions for the VAT number #} 
+         {% if hasVatNumber %}
           <dd class="govuk-summary-list__value">
             {{ vatNumber }}
           </dd>
           <dd class="govuk-summary-list__actions">
-            {# Logic to display the correct link actions for the VAT number #}
-            {% if hasVatNumber %}
               <ul class="govuk-summary-list__actions-list">
                 <li class="govuk-summary-list__actions-list-item">
                   <a class="govuk-link" href="/business-vat-registration-remove">
@@ -155,11 +155,15 @@
                   </a>
                 </li>
               </ul>
-            {% else %}
-              <a class="govuk-link" href="/business-vat-registration-number-change">
+           {% else %}
+           <dd class="govuk-summary-list__value">
+            Number not added
+          </dd> 
+          <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="/business-vat-registration-number-change">
                 Add<span class="govuk-visually-hidden"> VAT registration number</span>
               </a>
-            {% endif %}
+          {% endif %}
           </dd>
         </div>
         <div class="govuk-summary-list__row">

--- a/test/unit/presenters/business/business-details-presenter.test.js
+++ b/test/unit/presenters/business/business-details-presenter.test.js
@@ -130,7 +130,7 @@ describe('businessDetailsPresenter', () => {
         data.info.vat = null
         const result = businessDetailsPresenter(data, yar)
 
-        expect(result.vatNumber).toEqual('No number added')
+        expect(result.vatNumber).toEqual('Number not added')
       })
     })
   })


### PR DESCRIPTION
# Description
BUG FIX 
adding the "Number not added" text when there is no VAT number for a customer


Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity