### PR TITLE
Update business address mutation variables to support withUprn and withoutUprn schema changes

### DIFF
--- a/src/services/business/update-business-address-change-service.js
+++ b/src/services/business/update-business-address-change-service.js
@@ -66,7 +66,7 @@ const businessAddressVariables = (businessDetails) => {
 
   if (change.uprn) {
     // Address chosen via postcode lookup
-    variables.input.address = {
+    variables.input.address.withUprn = {
       buildingNumberRange: change.buildingNumberRange ?? null,
       buildingName: change.buildingName ?? null,
       flatName: change.flatName ?? null,
@@ -86,7 +86,7 @@ const businessAddressVariables = (businessDetails) => {
     }
   } else {
     // Address entered manually
-    variables.input.address = {
+    variables.input.address.withoutUprn = {
       buildingNumberRange: null,
       buildingName: null,
       flatName: null,

--- a/test/unit/services/business/update-business-addess-change-service.test.js
+++ b/test/unit/services/business/update-business-addess-change-service.test.js
@@ -63,20 +63,22 @@ describe('updateBusinessAddressChangeService', () => {
         input: {
           sbi: '107183280',
           address: {
-            buildingNumberRange: null,
-            buildingName: null,
-            flatName: null,
-            street: null,
-            city: 'Maidstone',
-            county: null,
-            postalCode: 'BA123 ABC',
-            country: 'United Kingdom',
-            line1: 'A different address',
-            line2: null,
-            line3: null,
-            line4: 'Maidstone',
-            line5: null,
-            uprn: null
+            withoutUprn: {
+              buildingNumberRange: null,
+              buildingName: null,
+              flatName: null,
+              street: null,
+              city: 'Maidstone',
+              county: null,
+              postalCode: 'BA123 ABC',
+              country: 'United Kingdom',
+              line1: 'A different address',
+              line2: null,
+              line3: null,
+              line4: 'Maidstone',
+              line5: null,
+              uprn: null
+            }
           }
         }
       })
@@ -117,22 +119,24 @@ describe('updateBusinessAddressChangeService', () => {
         input: {
           sbi: '107183280',
           address: {
-            buildingNumberRange: null,
-            buildingName: 'Test House',
-            flatName: null,
-            street: null,
-            city: 'London',
-            county: null,
-            postalCode: 'W1A 1AA',
-            country: 'United Kingdom',
-            dependentLocality: null,
-            doubleDependentLocality: null,
-            line1: null,
-            line2: null,
-            line3: null,
-            line4: null,
-            line5: null,
-            uprn: '1234567890'
+            withUprn: {
+              buildingNumberRange: null,
+              buildingName: 'Test House',
+              flatName: null,
+              street: null,
+              city: 'London',
+              county: null,
+              postalCode: 'W1A 1AA',
+              country: 'United Kingdom',
+              dependentLocality: null,
+              doubleDependentLocality: null,
+              line1: null,
+              line2: null,
+              line3: null,
+              line4: null,
+              line5: null,
+              uprn: '1234567890'
+            }
           }
         }
       })


### PR DESCRIPTION
The DAL team introduced a breaking change to business mutations involving addresses.

* Address inputs must now be wrapped in either address.withUprn or address.withoutUprn to match upstream requirements.
* Updated the variables we send to the DAL so that mutations conform to the new schema.

This change ensures that business address creation and modification work again in non-prod environments where the DAL schema update has been applied.