### PR TITLE
Add VSCode task to run lint:fix 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -92,7 +92,22 @@
       }
     },
     {
-      "label": "🧹 Clean Frontend",
+      "label": "🧹 Lint Fix",
+      "detail": "Automatically fix linting issues in the codebase",
+      "type": "shell",
+      "command": "npm run lint:fix; echo \"Code cleaned! ✨\"",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": true,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    },
+    {
+      "label": "🛠️ Clean Frontend",
       "detail": "Will drop the containers, remove related images and volumes",
       "type": "shell",
       "command": "docker compose down --rmi local -v; echo \"All done! 🎉\"",


### PR DESCRIPTION
This PR adds a new VSCode task to automatically run the lint:fix script defined in package.json.

Changes include:
* Task label: 🛠️ Lint Frontend (fix)
* Runs npm run lint:fix in a shared terminal panel
* Provides feedback in the terminal when the task completes

This will allow developers to quickly fix linting issues directly from VSCode without running commands manually.