### PR TITLE
Add conditional display for SBI in sub-header

### DIFF
--- a/src/views/common/sub-header/macro.njk
+++ b/src/views/common/sub-header/macro.njk
@@ -3,7 +3,9 @@
 
   <div class="govuk-grid-column-two-thirds">
       <h3 class="govuk-heading-s govuk-!-margin-bottom-1">{{ businessName }}</h3>
+      {% if sbi %}
       <p class="govuk-body-s govuk-!-margin-bottom-2">Single business identifier (SBI): {{ sbi }}</p>
+      {% endif %}
   </div>
 
   <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
This fix introduces a conditional check to display the Single Business Identifier (SBI) in the sub-header only if it is present. In practice this means that the SBI value will not be shown on personal pages but will be shown on business pages.

# Description

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity