### PR TITLE
Refactor business address services to be communal

### DIFF
--- a/src/mappers/address-lookup-mapper.js
+++ b/src/mappers/address-lookup-mapper.js
@@ -7,11 +7,11 @@
  */
 
 import { COUNTRY_NAMES } from '../constants/country-names.js'
-import { businessAddressLookupSchema } from '../schemas/business/business-address-lookup-schema.js'
+import { addressLookupSchema } from '../schemas/os-places/address-lookup-schema.js'
 
 const addressLookupMapper = (addresses) => {
   return addresses.map((address) => {
-    const { error } = businessAddressLookupSchema.validate(address)
+    const { error } = addressLookupSchema.validate(address)
 
     if (error) {
       return null

--- a/src/mappers/address-lookup-mapper.js
+++ b/src/mappers/address-lookup-mapper.js
@@ -3,13 +3,13 @@
  * for front-end display and DAL updating.
  * https://docs.os.uk/os-apis/accessing-os-apis/os-places-api/datasets as a reference for the datasets
  *
- * @module businessAddressLookupMapper
+ * @module addressLookupMapper
  */
 
 import { COUNTRY_NAMES } from '../constants/country-names.js'
 import { businessAddressLookupSchema } from '../schemas/business/business-address-lookup-schema.js'
 
-const businessAddressLookupMapper = (addresses) => {
+const addressLookupMapper = (addresses) => {
   return addresses.map((address) => {
     const { error } = businessAddressLookupSchema.validate(address)
 
@@ -66,5 +66,5 @@ const filterAndJoin = (addressesProperties) => {
 }
 
 export {
-  businessAddressLookupMapper
+  addressLookupMapper
 }

--- a/src/presenters/business/business-address-change-presenter.js
+++ b/src/presenters/business/business-address-change-presenter.js
@@ -8,7 +8,7 @@ const businessAddressChangePresenter = (data, payload) => {
     backLink: { href: '/business-details' },
     pageTitle: 'What is your business address?',
     metaDescription: 'Update the address for your business.',
-    businessPostcode: payload ?? data.changeBusinessPostcode?.businessPostcode ?? data.address.postcode,
+    postcode: payload ?? data.changeBusinessPostcode?.postcode ?? data.address.postcode,
     businessName: data.info.businessName ?? null,
     sbi: data.info.sbi ?? null,
     userName: data.customer.fullName ?? null

--- a/src/presenters/business/business-address-select-presenter.js
+++ b/src/presenters/business/business-address-select-presenter.js
@@ -11,7 +11,7 @@ const businessAddressSelectPresenter = (data) => {
     businessName: data.info.businessName ?? null,
     sbi: data.info.sbi ?? null,
     userName: data.customer.fullName ?? null,
-    postcode: data.changeBusinessPostcode.businessPostcode,
+    postcode: data.changeBusinessPostcode.postcode,
     displayAddresses: formatDisplayAddresses(data.changeBusinessAddresses)
   }
 }

--- a/src/routes/business/business-address-change-routes.js
+++ b/src/routes/business/business-address-change-routes.js
@@ -1,5 +1,5 @@
 import { fetchBusinessChangeService } from '../../services/business/fetch-business-change-service.js'
-import { businessUkPostcodeSchema } from '../../schemas/business/business-uk-postcode-schema.js'
+import { ukPostcodeSchema } from '../../schemas/os-places/uk-postcode-schema.js'
 import { businessAddressChangePresenter } from '../../presenters/business/business-address-change-presenter.js'
 import { BAD_REQUEST } from '../../constants/status-codes.js'
 import { setSessionData } from '../../utils/session/set-session-data.js'
@@ -23,11 +23,11 @@ const postBusinessAddressChange = {
   path: '/business-address-change',
   options: {
     validate: {
-      payload: businessUkPostcodeSchema,
+      payload: ukPostcodeSchema,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const { yar, auth, payload } = request
-        const pageData = await businessAddressChangeErrorService(yar, auth.credentials, payload.businessPostcode, err.details)
+        const pageData = await businessAddressChangeErrorService(yar, auth.credentials, payload.postcode, err.details)
 
         return h.view('business/business-address-change', pageData).code(BAD_REQUEST).takeover()
       }
@@ -37,10 +37,10 @@ const postBusinessAddressChange = {
     const { yar, auth, payload } = request
 
     setSessionData(yar, 'businessDetails', 'changeBusinessPostcode', payload)
-    const addresses = await addressLookupService(payload.businessPostcode, yar, 'business')
+    const addresses = await addressLookupService(payload.postcode, yar, 'business')
 
     if (addresses.error) {
-      const pageData = await businessAddressChangeErrorService(yar, auth.credentials, payload.businessPostcode, addresses.error)
+      const pageData = await businessAddressChangeErrorService(yar, auth.credentials, payload.postcode, addresses.error)
 
       return h.view('business/business-address-change', pageData).code(BAD_REQUEST).takeover()
     }

--- a/src/routes/business/business-address-change-routes.js
+++ b/src/routes/business/business-address-change-routes.js
@@ -3,7 +3,7 @@ import { businessUkPostcodeSchema } from '../../schemas/business/business-uk-pos
 import { businessAddressChangePresenter } from '../../presenters/business/business-address-change-presenter.js'
 import { BAD_REQUEST } from '../../constants/status-codes.js'
 import { setSessionData } from '../../utils/session/set-session-data.js'
-import { businessAddressLookupService } from '../../services/business/business-address-lookup-service.js'
+import { addressLookupService } from '../../services/os-places/address-lookup-service.js'
 import { businessAddressChangeErrorService } from '../../services/business/business-address-change-error-service.js'
 
 const getBusinessAddressChange = {
@@ -37,7 +37,7 @@ const postBusinessAddressChange = {
     const { yar, auth, payload } = request
 
     setSessionData(yar, 'businessDetails', 'changeBusinessPostcode', payload)
-    const addresses = await businessAddressLookupService(payload.businessPostcode, yar)
+    const addresses = await addressLookupService(payload.businessPostcode, yar, 'business')
 
     if (addresses.error) {
       const pageData = await businessAddressChangeErrorService(yar, auth.credentials, payload.businessPostcode, addresses.error)

--- a/src/routes/business/business-address-select.routes.js
+++ b/src/routes/business/business-address-select.routes.js
@@ -1,7 +1,7 @@
 import { fetchBusinessChangeService } from '../../services/business/fetch-business-change-service.js'
 import { businessAddressSelectPresenter } from '../../presenters/business/business-address-select-presenter.js'
 import { setSessionData } from '../../utils/session/set-session-data.js'
-import { businessAddressesSchema } from '../../schemas/business/business-addresses-schema.js'
+import { addressesSchema } from '../../schemas/os-places/addresses-schema.js'
 import { formatValidationErrors } from '../../utils/format-validation-errors.js'
 import { BAD_REQUEST } from '../../constants/status-codes.js'
 
@@ -22,7 +22,7 @@ const postBusinessAddressSelect = {
   path: '/business-address-select',
   options: {
     validate: {
-      payload: businessAddressesSchema,
+      payload: addressesSchema,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const { yar, auth } = request

--- a/src/schemas/os-places/address-lookup-schema.js
+++ b/src/schemas/os-places/address-lookup-schema.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 
-export const businessAddressLookupSchema = Joi.object({
+export const addressLookupSchema = Joi.object({
   properties: Joi.object({
     UPRN: Joi.string().required(),
     ADDRESS: Joi.string().required(),

--- a/src/schemas/os-places/addresses-schema.js
+++ b/src/schemas/os-places/addresses-schema.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 
 const CHOOSE_ADDRESS_ERROR = 'Choose an address'
 
-export const businessAddressesSchema = Joi.object({
+export const addressesSchema = Joi.object({
   addresses: Joi.string()
     .invalid('display')
     .required()

--- a/src/schemas/os-places/uk-postcode-schema.js
+++ b/src/schemas/os-places/uk-postcode-schema.js
@@ -1,8 +1,8 @@
 import Joi from 'joi'
 import { POSTCODE_MAX } from '../../constants/validation-fields.js'
 
-export const businessUkPostcodeSchema = Joi.object({
-  businessPostcode: Joi.string()
+export const ukPostcodeSchema = Joi.object({
+  postcode: Joi.string()
     .required()
     .uppercase()
     .max(POSTCODE_MAX)

--- a/src/services/business/business-address-lookup-service.js
+++ b/src/services/business/business-address-lookup-service.js
@@ -14,7 +14,7 @@ import { createLogger } from '../../utils/logger.js'
 import { setSessionData } from '../../utils/session/set-session-data.js'
 import { placesAPI } from 'osdatahub'
 import { constants as httpConstants } from 'node:http2'
-import { businessAddressLookupMapper } from '../../mappers/business-address-lookup-mapper.js'
+import { addressLookupMapper } from '../../mappers/address-lookup-mapper.js'
 
 const logger = createLogger()
 
@@ -37,7 +37,7 @@ const businessAddressLookupService = async (postcode, yar) => {
     }
   }
 
-  const mappedAddresses = businessAddressLookupMapper(addresses)
+  const mappedAddresses = addressLookupMapper(addresses)
   setSessionData(yar, 'businessDetails', 'changeBusinessAddresses', mappedAddresses)
 
   return mappedAddresses

--- a/src/services/os-places/address-lookup-service.js
+++ b/src/services/os-places/address-lookup-service.js
@@ -27,7 +27,14 @@ const addressLookupService = async (postcode, yar, context) => {
 
   if (!addresses?.length) {
     // Create a Joi-like error object to indicate that the postcode lookup returned no addresses
-    return context === 'business' ? businessAddressChangeError() : personalAddressChangeError()
+    return {
+      error: [
+        {
+          message: 'No addresses found for this postcode',
+          path: ['postcode']
+        }
+      ]
+    }
   }
 
   const mappedAddresses = addressLookupMapper(addresses)
@@ -36,28 +43,6 @@ const addressLookupService = async (postcode, yar, context) => {
   setSessionData(yar, `${context}Details`, `${changeAddress}`, mappedAddresses)
 
   return mappedAddresses
-}
-
-const businessAddressChangeError = () => {
-  return {
-    error: [
-      {
-        message: 'No addresses found for this postcode',
-        path: ['businessPostcode']
-      }
-    ]
-  }
-}
-
-const personalAddressChangeError = () => {
-  return {
-    error: [
-      {
-        message: 'No addresses found for this postcode',
-        path: ['personalPostcode']
-      }
-    ]
-  }
 }
 
 const fetchAddressesFromPostcodeLookup = async (postcode) => {

--- a/src/views/business/business-address-change.njk
+++ b/src/views/business/business-address-change.njk
@@ -36,12 +36,12 @@
             label: {
               text: "UK postcode"
             },
-            id: "business-postcode",
-            name: "businessPostcode",
-            value: businessPostcode,
+            id: "postcode",
+            name: "postcode",
+            value: postcode,
             classes: "govuk-!-width-one-third",
-            errorMessage: errors.businessPostcode and {
-            text: errors.businessPostcode.text
+            errorMessage: errors.postcode and {
+            text: errors.postcode.text
             }
           }) }}
 

--- a/test/unit/mappers/address-lookup-mapper.test.js
+++ b/test/unit/mappers/address-lookup-mapper.test.js
@@ -2,9 +2,9 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { businessAddressLookupMapper } from '../../../src/mappers/business-address-lookup-mapper.js'
+import { addressLookupMapper } from '../../../src/mappers/address-lookup-mapper.js'
 
-describe('business address lookup mapper', () => {
+describe('address lookup mapper', () => {
   const addresses = [
     {
       properties: {
@@ -28,7 +28,7 @@ describe('business address lookup mapper', () => {
   ]
 
   test('it maps a full OS Places address correctly', () => {
-    const results = businessAddressLookupMapper(addresses)
+    const results = addressLookupMapper(addresses)
 
     expect(results).toEqual([
       {
@@ -62,7 +62,7 @@ describe('business address lookup mapper', () => {
     })
 
     test('it handles optional fields correctly', () => {
-      const results = businessAddressLookupMapper(addresses)
+      const results = addressLookupMapper(addresses)
 
       expect(results).toEqual([
         {
@@ -89,7 +89,7 @@ describe('business address lookup mapper', () => {
     })
 
     test('it sets the county to null', () => {
-      const results = businessAddressLookupMapper(addresses)
+      const results = addressLookupMapper(addresses)
 
       expect(results[0].county).toEqual(null)
     })
@@ -101,7 +101,7 @@ describe('business address lookup mapper', () => {
     })
 
     test('it sets the county to null', () => {
-      const results = businessAddressLookupMapper(addresses)
+      const results = addressLookupMapper(addresses)
 
       expect(results[0].county).toEqual(null)
     })
@@ -113,7 +113,7 @@ describe('business address lookup mapper', () => {
     })
 
     test('it skips invalid addresses', () => {
-      const results = businessAddressLookupMapper(addresses)
+      const results = addressLookupMapper(addresses)
 
       expect(results).toEqual([])
     })
@@ -134,7 +134,7 @@ describe('business address lookup mapper', () => {
     })
 
     test('it only returns valid addresses', () => {
-      const results = businessAddressLookupMapper(addresses)
+      const results = addressLookupMapper(addresses)
 
       expect(results.length).toBe(1)
     })

--- a/test/unit/presenters/business/business-address-change-presenter.test.js
+++ b/test/unit/presenters/business/business-address-change-presenter.test.js
@@ -30,7 +30,7 @@ describe('businessAddressChangePresenter', () => {
         backLink: { href: '/business-details' },
         pageTitle: 'What is your business address?',
         metaDescription: 'Update the address for your business.',
-        businessPostcode: 'SK22 1DL',
+        postcode: 'SK22 1DL',
         businessName: 'Agile Farm Ltd',
         sbi: '123456789',
         userName: 'Alfred Waldron'
@@ -80,16 +80,16 @@ describe('businessAddressChangePresenter', () => {
     })
   })
 
-  describe('the "businessPostcode" property', () => {
+  describe('the "postcode" property', () => {
     describe('when provided with a changed business postcode', () => {
       beforeEach(() => {
-        data.changeBusinessPostcode.businessPostcode = 'NEW 123'
+        data.changeBusinessPostcode.postcode = 'NEW 123'
       })
 
-      test('it should return the changed postcode as the businessPostcode', () => {
+      test('it should return the changed postcode as the postcode', () => {
         const result = businessAddressChangePresenter(data)
 
-        expect(result.businessPostcode).toEqual(data.changeBusinessPostcode.businessPostcode)
+        expect(result.postcode).toEqual(data.changeBusinessPostcode.postcode)
       })
     })
 
@@ -101,7 +101,7 @@ describe('businessAddressChangePresenter', () => {
       test('it should return the payload as the business postcode', () => {
         const result = businessAddressChangePresenter(data, payload)
 
-        expect(result.businessPostcode).toEqual(payload)
+        expect(result.postcode).toEqual(payload)
       })
     })
   })

--- a/test/unit/presenters/business/business-address-select-presenter.test.js
+++ b/test/unit/presenters/business/business-address-select-presenter.test.js
@@ -17,7 +17,7 @@ describe('businessAddressSelectPresenter', () => {
         fullName: 'Alfred Waldron'
       },
       changeBusinessPostcode: {
-        businessPostcode: 'SK22 1DL'
+        postcode: 'SK22 1DL'
       },
       changeBusinessAddresses: [
         {

--- a/test/unit/routes/business/business-address-change-routes.test.js
+++ b/test/unit/routes/business/business-address-change-routes.test.js
@@ -4,7 +4,7 @@ import { describe, test, expect, vi, beforeEach } from 'vitest'
 // Things we need to mock
 import { fetchBusinessChangeService } from '../../../../src/services/business/fetch-business-change-service.js'
 import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
-import { businessAddressLookupService } from '../../../../src/services/business/business-address-lookup-service.js'
+import { addressLookupService } from '../../../../src/services/os-places/address-lookup-service.js'
 import { businessAddressChangeErrorService } from '../../../../src/services/business/business-address-change-error-service.js'
 
 // Thing under test
@@ -20,8 +20,8 @@ vi.mock('../../../../src/utils/session/set-session-data.js', () => ({
   setSessionData: vi.fn()
 }))
 
-vi.mock('../../../../src/services/business/business-address-lookup-service.js', () => ({
-  businessAddressLookupService: vi.fn()
+vi.mock('../../../../src/services/os-places/address-lookup-service.js', () => ({
+  addressLookupService: vi.fn()
 }))
 
 vi.mock('../../../../src/services/business/business-address-change-error-service.js', () => ({
@@ -98,7 +98,7 @@ describe('business address change routes', () => {
       describe('and the validation passes', () => {
         describe('and addresses are found for the postcode', () => {
           beforeEach(() => {
-            businessAddressLookupService.mockResolvedValue([{ address1: '10 High Street London SK22 1DL' }])
+            addressLookupService.mockResolvedValue([{ address1: '10 High Street London SK22 1DL' }])
           })
 
           test('it sets session data', async () => {
@@ -121,7 +121,7 @@ describe('business address change routes', () => {
 
         describe('and no addresses are found for the postcode', () => {
           beforeEach(() => {
-            businessAddressLookupService.mockResolvedValue({ error: 'No addresses found for this postcode' })
+            addressLookupService.mockResolvedValue({ error: 'No addresses found for this postcode' })
             businessAddressChangeErrorService.mockResolvedValue(getPageDataError())
           })
 

--- a/test/unit/routes/business/business-address-change-routes.test.js
+++ b/test/unit/routes/business/business-address-change-routes.test.js
@@ -90,7 +90,7 @@ describe('business address change routes', () => {
   describe('POST /business-address-change', () => {
     beforeEach(() => {
       request.payload = {
-        businessPostcode: 'SK22 1DL'
+        postcode: 'SK22 1DL'
       }
     })
 
@@ -141,7 +141,7 @@ describe('business address change routes', () => {
             details: [
               {
                 message: 'Invalid postcode',
-                path: ['businessPostcode'],
+                path: ['postcode'],
                 type: 'string.pattern.base'
               }
             ]
@@ -156,7 +156,7 @@ describe('business address change routes', () => {
           expect(businessAddressChangeErrorService).toHaveBeenCalledWith(
             request.yar,
             request.auth.credentials,
-            request.payload.businessPostcode,
+            request.payload.postcode,
             err.details
           )
         })
@@ -176,7 +176,7 @@ const getPageData = () => {
     backLink: { href: '/business-details' },
     pageTitle: 'What is your business address?',
     metaDescription: 'Update the address for your business.',
-    businessPostcode: 'SK22 1DL',
+    postcode: 'SK22 1DL',
     businessName: 'Agile Farm Ltd',
     sbi: '123456789',
     userName: 'Alfred Waldron'
@@ -188,7 +188,7 @@ const getPageDataError = () => {
     backLink: { href: '/business-details' },
     pageTitle: 'What is your business address?',
     metaDescription: 'Update the address for your business.',
-    businessPostcode: 'SK22 1DL',
+    postcode: 'SK22 1DL',
     businessName: 'Agile Farm Ltd',
     sbi: '123456789',
     userName: 'Alfred Waldron',

--- a/test/unit/routes/business/business-address-select-routes.test.js
+++ b/test/unit/routes/business/business-address-select-routes.test.js
@@ -158,7 +158,7 @@ const getMockData = () => {
       fullName: 'Alfred Waldron'
     },
     changeBusinessPostcode: {
-      businessPostcode: 'SK22 1DL'
+      postcode: 'SK22 1DL'
     },
     changeBusinessAddresses: [
       {

--- a/test/unit/schemas/os-places/address-lookup-schema.test.js
+++ b/test/unit/schemas/os-places/address-lookup-schema.test.js
@@ -2,14 +2,14 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { businessAddressLookupSchema } from '../../../../src/schemas/business/business-address-lookup-schema.js'
+import { addressLookupSchema } from '../../../../src/schemas/os-places/address-lookup-schema.js'
 
-describe('businessAddressLookupSchema', () => {
+describe('addressLookupSchema', () => {
   let payload
   let schema
 
   beforeEach(() => {
-    schema = businessAddressLookupSchema
+    schema = addressLookupSchema
 
     payload = {
       properties: {

--- a/test/unit/schemas/os-places/addresses-schema.test.js
+++ b/test/unit/schemas/os-places/addresses-schema.test.js
@@ -2,14 +2,14 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { businessAddressesSchema } from '../../../../src/schemas/business/business-addresses-schema.js'
+import { addressesSchema } from '../../../../src/schemas/os-places/addresses-schema.js'
 
 describe('business addresses schema', () => {
   let payload
   let schema
 
   beforeEach(() => {
-    schema = businessAddressesSchema
+    schema = addressesSchema
 
     payload = {
       addresses: '100022950089, 14, New Business, Random Street, LONDON, E1 6AN'

--- a/test/unit/schemas/os-places/uk-postcode-schema.test.js
+++ b/test/unit/schemas/os-places/uk-postcode-schema.test.js
@@ -2,18 +2,18 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 
 // Thing under test
-import { businessUkPostcodeSchema } from '../../../../src/schemas/business/business-uk-postcode-schema.js'
+import { ukPostcodeSchema } from '../../../../src/schemas/os-places/uk-postcode-schema.js'
 import { POSTCODE_MAX } from '../../../../src/constants/validation-fields.js'
 
-describe('business UK postcode schema', () => {
+describe('uk postcode schema', () => {
   let payload
   let schema
 
   beforeEach(() => {
-    schema = businessUkPostcodeSchema
+    schema = ukPostcodeSchema
 
     payload = {
-      businessPostcode: 'BA1 3TF'
+      postcode: 'BA1 3TF'
     }
   })
 
@@ -27,9 +27,9 @@ describe('business UK postcode schema', () => {
   })
 
   describe('when invalid data is provided', () => {
-    describe('because "businessPostcode" is missing', () => {
+    describe('because "postcode" is missing', () => {
       beforeEach(() => {
-        delete payload.businessPostcode
+        delete payload.postcode
       })
 
       test('it fails validation', () => {
@@ -37,16 +37,16 @@ describe('business UK postcode schema', () => {
 
         expect(error.details[0]).toEqual(expect.objectContaining({
           message: 'Enter a postcode',
-          path: ['businessPostcode'],
+          path: ['postcode'],
           type: 'any.required'
         }))
         expect(value).toEqual(payload)
       })
     })
 
-    describe('because "businessPostcode" is an empty string', () => {
+    describe('because "postcode" is an empty string', () => {
       beforeEach(() => {
-        payload.businessPostcode = ''
+        payload.postcode = ''
       })
 
       test('it fails validation', () => {
@@ -54,16 +54,16 @@ describe('business UK postcode schema', () => {
 
         expect(error.details[0]).toEqual(expect.objectContaining({
           message: 'Enter a postcode',
-          path: ['businessPostcode'],
+          path: ['postcode'],
           type: 'string.empty'
         }))
         expect(value).toEqual(payload)
       })
     })
 
-    describe('because "businessPostcode" is longer than POSTCODE_MAX characters', () => {
+    describe('because "postcode" is longer than POSTCODE_MAX characters', () => {
       beforeEach(() => {
-        payload.businessPostcode = 'A'.repeat(POSTCODE_MAX + 1)
+        payload.postcode = 'A'.repeat(POSTCODE_MAX + 1)
       })
 
       test('it fails validation', () => {
@@ -71,16 +71,16 @@ describe('business UK postcode schema', () => {
 
         expect(error.details[0]).toEqual(expect.objectContaining({
           message: `Postal code must be ${POSTCODE_MAX} characters or less`,
-          path: ['businessPostcode'],
+          path: ['postcode'],
           type: 'string.max'
         }))
         expect(value).toEqual(payload)
       })
     })
 
-    describe('because "businessPostcode" is invalid format', () => {
+    describe('because "postcode" is invalid format', () => {
       beforeEach(() => {
-        payload.businessPostcode = 'INVALID1'
+        payload.postcode = 'INVALID1'
       })
 
       test('it fails validation', () => {
@@ -88,23 +88,23 @@ describe('business UK postcode schema', () => {
 
         expect(error.details[0]).toEqual(expect.objectContaining({
           message: 'Enter a full UK postcode, like AA3 1AB',
-          path: ['businessPostcode'],
+          path: ['postcode'],
           type: 'string.pattern.base'
         }))
         expect(value).toEqual(payload)
       })
     })
 
-    describe('because "businessPostcode" is lowercase', () => {
+    describe('because "postcode" is lowercase', () => {
       beforeEach(() => {
-        payload.businessPostcode = 'ba1 3tf'
+        payload.postcode = 'ba1 3tf'
       })
 
       test('it converts to uppercase and validates', () => {
         const { error, value } = schema.validate(payload, { abortEarly: false })
 
         expect(error).toBeUndefined()
-        expect(value.businessPostcode).toEqual('BA1 3TF')
+        expect(value.postcode).toEqual('BA1 3TF')
       })
     })
   })

--- a/test/unit/services/business/business-address-change-error-service.test.js
+++ b/test/unit/services/business/business-address-change-error-service.test.js
@@ -61,7 +61,7 @@ describe('businessAddressChangeErrorService', () => {
         backLink: { href: '/business-details' },
         pageTitle: 'What is your business address?',
         metaDescription: 'Update the address for your business.',
-        businessPostcode: 'AB12 3CD',
+        postcode: 'AB12 3CD',
         businessName: 'Test Business',
         sbi: '123456789',
         userName: 'Alfred Waldron',
@@ -94,7 +94,7 @@ const mockBusinessDetails = () => {
       fullName: 'Alfred Waldron'
     },
     changeBusinessPostcode: {
-      businessPostcode: 'AB12 3CD'
+      postcode: 'AB12 3CD'
     }
   }
 }

--- a/test/unit/services/business/business-address-lookup-service.test.js
+++ b/test/unit/services/business/business-address-lookup-service.test.js
@@ -2,7 +2,7 @@
 import { vi, describe, test, expect, beforeEach } from 'vitest'
 
 // Things we need to mock
-import { businessAddressLookupMapper } from '../../../../src/mappers/business-address-lookup-mapper.js'
+import { addressLookupMapper } from '../../../../src/mappers/address-lookup-mapper.js'
 import { setSessionData } from '../../../../src/utils/session/set-session-data.js'
 import { placesAPI } from 'osdatahub'
 import { constants as httpConstants } from 'node:http2'
@@ -11,8 +11,8 @@ import { constants as httpConstants } from 'node:http2'
 import { businessAddressLookupService } from '../../../../src/services/business/business-address-lookup-service.js'
 
 // Mocks
-vi.mock('../../../../src/mappers/business-address-lookup-mapper.js', () => ({
-  businessAddressLookupMapper: vi.fn()
+vi.mock('../../../../src/mappers/address-lookup-mapper.js', () => ({
+  addressLookupMapper: vi.fn()
 }))
 
 vi.mock('../../../../src/utils/session/set-session-data.js', () => ({

--- a/test/unit/services/business/business-address-lookup-service.test.js
+++ b/test/unit/services/business/business-address-lookup-service.test.js
@@ -50,14 +50,14 @@ describe('businessAddressLookupService', () => {
   describe('when called with a valid postcode', () => {
     beforeEach(() => {
       placesAPI.postcode.mockResolvedValue(mockAddresses)
-      businessAddressLookupMapper.mockReturnValue(mappedMockAddresses)
+      addressLookupMapper.mockReturnValue(mappedMockAddresses)
     })
 
     test('returns mapped addresses and sets them in session when API returns results', async () => {
       const result = await businessAddressLookupService(postcode, yar)
 
       expect(result).toEqual(mappedMockAddresses)
-      expect(businessAddressLookupMapper).toHaveBeenCalledWith(mockAddresses.features)
+      expect(addressLookupMapper).toHaveBeenCalledWith(mockAddresses.features)
       expect(setSessionData).toHaveBeenCalledWith(
         yar,
         'businessDetails',
@@ -84,7 +84,7 @@ describe('businessAddressLookupService', () => {
         ]
       })
 
-      expect(businessAddressLookupMapper).not.toHaveBeenCalled()
+      expect(addressLookupMapper).not.toHaveBeenCalled()
       expect(setSessionData).not.toHaveBeenCalled()
     })
   })
@@ -104,7 +104,7 @@ describe('businessAddressLookupService', () => {
         statusCode: httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
         errors: [error]
       })
-      expect(businessAddressLookupMapper).not.toHaveBeenCalled()
+      expect(addressLookupMapper).not.toHaveBeenCalled()
       expect(setSessionData).not.toHaveBeenCalled()
     })
   })

--- a/test/unit/services/os-places/address-lookup-service.test.js
+++ b/test/unit/services/os-places/address-lookup-service.test.js
@@ -89,38 +89,19 @@ describe('addressLookupService', () => {
       placesAPI.postcode.mockResolvedValue({ features: [] })
     })
 
-    describe('and the context is for the business details data', () => {
-      test('returns a Joi-like error object', async () => {
-        const result = await addressLookupService(postcode, yar, 'business')
+    test('returns a Joi-like error object', async () => {
+      const result = await addressLookupService(postcode, yar, 'business')
 
-        expect(result).toEqual({
-          error: [
-            {
-              message: 'No addresses found for this postcode',
-              path: ['businessPostcode']
-            }
-          ]
-        })
-        expect(addressLookupMapper).not.toHaveBeenCalled()
-        expect(setSessionData).not.toHaveBeenCalled()
+      expect(result).toEqual({
+        error: [
+          {
+            message: 'No addresses found for this postcode',
+            path: ['postcode']
+          }
+        ]
       })
-    })
-
-    describe('and the context is for the personal details data', () => {
-      test('returns a Joi-like error object', async () => {
-        const result = await addressLookupService(postcode, yar, 'personal')
-
-        expect(result).toEqual({
-          error: [
-            {
-              message: 'No addresses found for this postcode',
-              path: ['personalPostcode']
-            }
-          ]
-        })
-        expect(addressLookupMapper).not.toHaveBeenCalled()
-        expect(setSessionData).not.toHaveBeenCalled()
-      })
+      expect(addressLookupMapper).not.toHaveBeenCalled()
+      expect(setSessionData).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
**Summary**

This PR refactors several business address–related schemas and services to make them reusable for the personal details pages.

**Details**
* Moved shared schemas and services into a new os-places folder.
* Updated imports and references to point to the new shared location.
* Ensured the existing business address functionality remains unchanged.
* Prepared the structure for reuse within the personal details pages.

**Why**

The business address logic and validation were previously duplicated or tightly coupled to the business-specific flow.
By making these components communal, we can reuse them for the personal details pages and reduce maintenance overhead.