### PR TITLE
Remove jwk-to-pem dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "http-status-codes": "2.3.0",
         "https-proxy-agent": "7.0.6",
         "ioredis": "5.4.1",
-        "jwk-to-pem": "2.0.7",
         "moment": "2.30.1",
         "nunjucks": "3.2.4",
         "osdatahub": "0.2.2",
@@ -3613,18 +3612,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3798,12 +3785,6 @@
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-      "license": "MIT"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3840,12 +3821,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -4938,21 +4913,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -6785,16 +6745,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6813,17 +6763,6 @@
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -7048,6 +6987,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -7911,17 +7851,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jwk-to-pem": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
-      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "asn1.js": "^5.3.0",
-        "elliptic": "^6.6.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8317,18 +8246,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "http-status-codes": "2.3.0",
     "https-proxy-agent": "7.0.6",
     "ioredis": "5.4.1",
-    "jwk-to-pem": "2.0.7",
     "moment": "2.30.1",
     "nunjucks": "3.2.4",
     "osdatahub": "0.2.2",

--- a/src/auth/verify-token.js
+++ b/src/auth/verify-token.js
@@ -1,6 +1,6 @@
+import { createPublicKey } from 'node:crypto'
 import Wreck from '@hapi/wreck'
 import Jwt from '@hapi/jwt'
-import jwkToPem from 'jwk-to-pem'
 import { getOidcConfig } from './get-oidc-config.js'
 
 async function verifyToken (token) {
@@ -12,7 +12,7 @@ async function verifyToken (token) {
   const { keys } = payload
 
   // Convert the JSON Web Key (JWK) to a PEM-encoded public key so that it can be used to verify the token
-  const pem = jwkToPem(keys[0])
+  const pem = createPublicKey({ key: keys[0], format: 'jwk' }).export({ type: 'spki', format: 'pem' })
 
   // Check that the token is signed with the appropriate key by decoding it and verifying the signature using the public key
   const decoded = Jwt.token.decode(token)

--- a/test/unit/auth/verify-token.test.js
+++ b/test/unit/auth/verify-token.test.js
@@ -1,0 +1,101 @@
+import { vi, beforeEach, describe, test, expect } from 'vitest'
+
+const mockOidcConfig = { jwks_uri: 'https://example.com/jwks' }
+const mockGetOidcConfig = vi.fn()
+vi.mock('../../../src/auth/get-oidc-config.js', () => ({
+  getOidcConfig: mockGetOidcConfig
+}))
+
+const mockJwkKey = { kty: 'RSA', n: 'mock-n', e: 'AQAB' }
+const mockWreckGet = vi.fn()
+vi.mock('@hapi/wreck', () => ({
+  default: {
+    get: mockWreckGet
+  }
+}))
+
+const mockPem = '-----BEGIN PUBLIC KEY-----\nmock-pem\n-----END PUBLIC KEY-----'
+const mockExport = vi.fn()
+const mockCreatePublicKey = vi.fn()
+vi.mock('node:crypto', () => ({
+  createPublicKey: mockCreatePublicKey
+}))
+
+const mockDecoded = { header: {}, payload: {}, signature: '' }
+const mockJwtDecode = vi.fn()
+const mockJwtVerify = vi.fn()
+vi.mock('@hapi/jwt', () => ({
+  default: {
+    token: {
+      decode: mockJwtDecode,
+      verify: mockJwtVerify
+    }
+  }
+}))
+
+const { verifyToken } = await import('../../../src/auth/verify-token.js')
+
+const mockToken = 'mock.jwt.token'
+
+describe('verifyToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetOidcConfig.mockResolvedValue(mockOidcConfig)
+    mockWreckGet.mockResolvedValue({ payload: { keys: [mockJwkKey] } })
+    mockExport.mockReturnValue(mockPem)
+    mockCreatePublicKey.mockReturnValue({ export: mockExport })
+    mockJwtDecode.mockReturnValue(mockDecoded)
+    mockJwtVerify.mockReturnValue(undefined)
+  })
+
+  test('should call getOidcConfig to retrieve the JWKS URI', async () => {
+    await verifyToken(mockToken)
+    expect(mockGetOidcConfig).toHaveBeenCalledOnce()
+  })
+
+  test('should fetch keys from the jwks_uri returned by oidc config', async () => {
+    await verifyToken(mockToken)
+    expect(mockWreckGet).toHaveBeenCalledWith(mockOidcConfig.jwks_uri, { json: true })
+  })
+
+  test('should convert the first JWK to a PEM-encoded public key', async () => {
+    await verifyToken(mockToken)
+    expect(mockCreatePublicKey).toHaveBeenCalledWith({ key: mockJwkKey, format: 'jwk' })
+    expect(mockExport).toHaveBeenCalledWith({ type: 'spki', format: 'pem' })
+  })
+
+  test('should decode the token', async () => {
+    await verifyToken(mockToken)
+    expect(mockJwtDecode).toHaveBeenCalledWith(mockToken)
+  })
+
+  test('should verify the decoded token using the PEM key and RS256 algorithm', async () => {
+    await verifyToken(mockToken)
+    expect(mockJwtVerify).toHaveBeenCalledWith(mockDecoded, { key: mockPem, algorithm: 'RS256' })
+  })
+
+  test('should resolve without returning a value on success', async () => {
+    const result = await verifyToken(mockToken)
+    expect(result).toBeUndefined()
+  })
+
+  test('should throw if getOidcConfig fails', async () => {
+    mockGetOidcConfig.mockRejectedValue(new Error('OIDC config unavailable'))
+    await expect(verifyToken(mockToken)).rejects.toThrow('OIDC config unavailable')
+  })
+
+  test('should throw if fetching JWKS fails', async () => {
+    mockWreckGet.mockRejectedValue(new Error('JWKS fetch failed'))
+    await expect(verifyToken(mockToken)).rejects.toThrow('JWKS fetch failed')
+  })
+
+  test('should throw if token decoding fails', async () => {
+    mockJwtDecode.mockImplementation(() => { throw new Error('Invalid token format') })
+    await expect(verifyToken(mockToken)).rejects.toThrow('Invalid token format')
+  })
+
+  test('should throw if token verification fails', async () => {
+    mockJwtVerify.mockImplementation(() => { throw new Error('Invalid signature') })
+    await expect(verifyToken(mockToken)).rejects.toThrow('Invalid signature')
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-1048
https://defra-digital-team.slack.com/archives/C09P7PXLEA0/p1775816974296079

This PR removes the jwk-to-pem dependency and replaces it with native functionality from Node’s crypto module.

Many frontend services use jwk-to-pem to support verification of signed tokens after sign-in (both internal and external frontends).

A low-severity vulnerability has recently been identified in elliptic, a dependency of jwk-to-pem. This may have appeared in GitHub Security alerts or during npm audit.

The elliptic package does not appear to be actively maintained, and there has been no resolution to the reported vulnerability.

**Change**
Recent versions of Node.js provide the required functionality via the built-in node:crypto module, meaning jwk-to-pem is no longer required.

**This PR:**
Removes the jwk-to-pem dependency
Updates token verification logic to use node:crypto