### PR TITLE
Bumping the frontend to its first #major version since go live

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-frontend",
-  "version": "0.129.0",
+  "version": "1.0.0",
   "description": "SFD Frontend",
   "sideEffects": false,
   "main": "src/index.js",


### PR DESCRIPTION
A PR to bump the version of the service to v1.0.0 since its gone live