### PR TITLE
Align docker compose file with sfd services

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,3 +1,4 @@
+name: fcp-sfd
 services:
   fcp-sfd-frontend:
     ports:
@@ -16,7 +17,7 @@ services:
       - fcp-sfd
 
   fcp-dal-api:
-    ports: 
+    ports:
       - 3005:3005
     networks:
       - fcp-sfd

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       target: development
+    env_file:
+      - .env
     links:
       - 'redis:redis'
     depends_on:


### PR DESCRIPTION
As part of the tech debt cleanup, we are aligning the docker compose files within the sfd services. This is to enable us to spin up all the containers with a single command and have non of the services clashing on ports.
