### PR TITLE
SFD2-1052 Create GitHub action for detecting CDP template drift (package.json)

### DIFF
--- a/.github/drift-config.json
+++ b/.github/drift-config.json
@@ -1,0 +1,16 @@
+{
+  "templateRepo": "DEFRA/cdp-node-frontend-template",
+  "templateBranch": "main",
+  "ignoredTopLevelFields": [
+    "name",
+    "version",
+    "description",
+    "contributors",
+    "author",
+    "imports",
+    "sideEffects",
+    "scripts"
+  ],
+  "ignoredDependencies": [],
+  "ignoredDevDependencies": []
+}

--- a/.github/scripts/detect-drift.js
+++ b/.github/scripts/detect-drift.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const [, , servicePkgPath, templatePkgPath] = process.argv
+
+if (!servicePkgPath || !templatePkgPath) {
+  console.error(
+    'Usage: node detect-drift.js <service-package.json> <template-package.json>'
+  )
+  process.exit(2)
+}
+
+const config = JSON.parse(
+  readFileSync(resolve(scriptDir, '..', 'drift-config.json'), 'utf8')
+)
+const servicePkg = JSON.parse(
+  readFileSync(resolve(servicePkgPath), 'utf8')
+)
+const templatePkg = JSON.parse(
+  readFileSync(resolve(templatePkgPath), 'utf8')
+)
+
+const ignoredFields = new Set([
+  ...(config.ignoredTopLevelFields || []),
+  'dependencies',
+  'devDependencies',
+  'overrides'
+])
+const ignoredDeps = new Set(config.ignoredDependencies || [])
+const ignoredDevDeps = new Set(config.ignoredDevDependencies || [])
+
+// Compare top-level fields
+const topLevelDiffs = []
+
+for (const key of Object.keys(templatePkg)) {
+  if (ignoredFields.has(key)) continue
+
+  const tVal = JSON.stringify(templatePkg[key])
+  const sVal = JSON.stringify(servicePkg[key])
+
+  if (tVal !== sVal) {
+    topLevelDiffs.push({
+      field: key,
+      service: key in servicePkg ? servicePkg[key] : '_(not set)_',
+      template: templatePkg[key]
+    })
+  }
+}
+
+// Compare dependency-like objects (dependencies, devDependencies, overrides)
+// Only flags packages that exist in the template — service-only packages are
+// intentional additions and are NOT considered drift.
+function compareDeps(templateDeps, serviceDeps, ignored) {
+  const mismatched = []
+  const missing = []
+
+  for (const [pkg, tVer] of Object.entries(templateDeps || {})) {
+    if (ignored.has(pkg)) continue
+
+    const sVer = (serviceDeps || {})[pkg]
+
+    if (sVer === undefined) {
+      missing.push({ name: pkg, templateVersion: tVer })
+    } else if (sVer !== tVer) {
+      mismatched.push({ name: pkg, serviceVersion: sVer, templateVersion: tVer })
+    }
+  }
+
+  return { mismatched, missing }
+}
+
+const depsDrift = compareDeps(
+  templatePkg.dependencies, servicePkg.dependencies, ignoredDeps
+)
+const devDepsDrift = compareDeps(
+  templatePkg.devDependencies, servicePkg.devDependencies, ignoredDevDeps
+)
+const overridesDrift = compareDeps(
+  templatePkg.overrides, servicePkg.overrides, new Set()
+)
+
+// Determine whether any drift exists
+const hasDrift =
+  topLevelDiffs.length > 0 ||
+  depsDrift.mismatched.length > 0 ||
+  depsDrift.missing.length > 0 ||
+  devDepsDrift.mismatched.length > 0 ||
+  devDepsDrift.missing.length > 0 ||
+  overridesDrift.mismatched.length > 0 ||
+  overridesDrift.missing.length > 0
+
+if (!hasDrift) {
+  console.log('No drift detected between service and template package.json.')
+  process.exit(0)
+}
+
+// Build Markdown report
+function formatVal(val) {
+  if (val === '_(not set)_') return val
+  if (typeof val === 'object' && val !== null) {
+    return '`' + JSON.stringify(val) + '`'
+  }
+  return '`' + String(val) + '`'
+}
+
+const lines = [
+  '# CDP Template Drift Report\n',
+  `**Template**: \`${config.templateRepo}\` (\`${config.templateBranch}\`)`,
+  `**Detected on**: ${new Date().toISOString().split('T')[0]}\n`,
+  '---\n'
+]
+
+// Top-level differences
+if (topLevelDiffs.length > 0) {
+  lines.push('## Top-Level Field Differences\n')
+  lines.push('| Field | Service | Template |')
+  lines.push('|-------|---------|----------|')
+  for (const d of topLevelDiffs) {
+    lines.push(
+      `| \`${d.field}\` | ${formatVal(d.service)} | ${formatVal(d.template)} |`
+    )
+  }
+  lines.push('')
+}
+
+// Dependency section helper
+function addDepsSection(title, drift) {
+  if (drift.mismatched.length === 0 && drift.missing.length === 0) return
+
+  lines.push(`## ${title}\n`)
+
+  if (drift.mismatched.length > 0) {
+    lines.push('### Version Mismatches\n')
+    lines.push('| Package | Service | Template |')
+    lines.push('|---------|---------|----------|')
+    for (const d of drift.mismatched) {
+      lines.push(
+        `| \`${d.name}\` | \`${d.serviceVersion}\` | \`${d.templateVersion}\` |`
+      )
+    }
+    lines.push('')
+  }
+
+  if (drift.missing.length > 0) {
+    lines.push('### Missing from Service\n')
+    lines.push('| Package | Template Version |')
+    lines.push('|---------|------------------|')
+    for (const d of drift.missing) {
+      lines.push(`| \`${d.name}\` | \`${d.templateVersion}\` |`)
+    }
+    lines.push('')
+  }
+}
+
+addDepsSection('`dependencies`', depsDrift)
+addDepsSection('`devDependencies`', devDepsDrift)
+addDepsSection('`overrides`', overridesDrift)
+
+const report = lines.join('\n')
+writeFileSync('cdp-template-drift-report.md', report)
+console.log('Drift detected. Report written to cdp-template-drift-report.md.')
+process.exit(1)

--- a/.github/scripts/detect-drift.js
+++ b/.github/scripts/detect-drift.js
@@ -110,7 +110,7 @@ function formatVal(val) {
 const lines = [
   '# CDP Template Drift Report\n',
   `**Template**: \`${config.templateRepo}\` (\`${config.templateBranch}\`)`,
-  `**Detected on**: ${new Date().toISOString().split('T')[0]}\n`,
+  `**Detected on**: ${new Date().toLocaleDateString('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' })}\n`,
   '---\n'
 ]
 

--- a/.github/workflows/detect-template-drift.yml
+++ b/.github/workflows/detect-template-drift.yml
@@ -1,0 +1,101 @@
+name: Detect CDP Template Drift
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  detect-drift:
+    name: Detect Template Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout service repository
+        uses: actions/checkout@v4
+
+      - name: Read drift config
+        id: config
+        run: |
+          echo "templateRepo=$(jq -r '.templateRepo' .github/drift-config.json)" >> "$GITHUB_OUTPUT"
+          echo "templateBranch=$(jq -r '.templateBranch' .github/drift-config.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout CDP template
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.config.outputs.templateRepo }}
+          ref: ${{ steps.config.outputs.templateBranch }}
+          path: cdp-template
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run drift detection
+        id: drift
+        run: |
+          set +e
+          node .github/scripts/detect-drift.js ./package.json ./cdp-template/package.json
+          EXIT_CODE=$?
+          set -e
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "detected=false" >> "$GITHUB_OUTPUT"
+          elif [ $EXIT_CODE -eq 1 ]; then
+            echo "detected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Script failed with unexpected exit code $EXIT_CODE"
+            exit $EXIT_CODE
+          fi
+
+      - name: Create or update GitHub issue
+        if: steps.drift.outputs.detected == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            const report = fs.readFileSync('cdp-template-drift-report.md', 'utf8')
+            const label = 'cdp-template-drift'
+
+            // Check for an existing open drift issue
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open'
+            })
+
+            if (issues.length > 0) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body: report
+              })
+              core.info(`Updated existing issue #${issues[0].number}`)
+            } else {
+              // Ensure the label exists
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'e99695',
+                  description: 'CDP template package.json drift detected'
+                })
+              } catch (e) {
+                // Label already exists — ignore
+              }
+
+              const { data: issue } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'CDP Template Drift Detected in package.json',
+                body: report,
+                labels: [label]
+              })
+              core.info(`Created new issue #${issue.number}`)
+            }

--- a/.github/workflows/detect-template-drift.yml
+++ b/.github/workflows/detect-template-drift.yml
@@ -1,9 +1,6 @@
 name: Detect CDP Template Drift
 
 on:
-  push:
-    branches:
-      - sfd2-1047-create-github-action-to-detect-cdp-template-drift
   schedule:
     - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
   workflow_dispatch:

--- a/.github/workflows/detect-template-drift.yml
+++ b/.github/workflows/detect-template-drift.yml
@@ -1,9 +1,7 @@
 name: Detect CDP Template Drift
 
 on:
-  push:
-    branches:
-      - sfd2-1047-create-github-action-to-detect-cdp-template-drift
+
   schedule:
     - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
   workflow_dispatch:

--- a/.github/workflows/detect-template-drift.yml
+++ b/.github/workflows/detect-template-drift.yml
@@ -1,6 +1,9 @@
 name: Detect CDP Template Drift
 
 on:
+  push:
+    branches:
+      - sfd2-1047-create-github-action-to-detect-cdp-template-drift
   schedule:
     - cron: "0 8 * * 1" # Every Monday at 08:00 UTC
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 .eslintcache
 .env
 .public
+drift-report.md
 .github/prompts
 .github/skills
 .github/agents


### PR DESCRIPTION
# SFD2-1052 Create GitHub action for detecting CDP template drift (package.json)
 
Ticket - [SFD2-1052](https://eaflood.atlassian.net/browse/SFD2-1052)
NB - The branch name incorrectly references ticket `sfd2-1047`. This is a typo.

## Description

The frontend repository is initially created using the CDP template, which includes a curated package.json. The CDP team actively maintains this template, ensuring dependencies are secure, up to date, and well-supported.

Over time, our service package.json may drift from the template due to:
- Dependency updates made locally
- Missed updates from the CDP template
- Changes in best practices or supported packages

To ensure we continue benefiting from the CDP team’s maintenance and security efforts, we should introduce an automated mechanism to detect drift.

## Changes

- Addition of a `.github/drift-config.json` config file. Specifies what `package.json` fields to ignore that are intentionally different e.g. `name`, `version`, `scripts` etc. Can change `templateRepo` to point to the `cdp-node-backend-template` repository to use on backend microservices.
- Addition of a `.github/scripts/detect-drift.js` script. Compares the project's `package.json` file to the CDP template's currenty `package.json` file (`main` branch).
- Addition of a `.github/workflows/detect-template-drift.yml` GitHub action that will execute the `detect-drift` script using the `drift-config` file. For any detected template drift a GitHub issue will be opened and will include a drift report. The action will run every Monday @ 08:00 (UTC).


[SFD2-1047]: https://eaflood.atlassian.net/browse/SFD2-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SFD2-1052]: https://eaflood.atlassian.net/browse/SFD2-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ