### PR TITLE
SFD2-149 Review DAL error handling

### DIFF
--- a/src/auth/get-permissions.js
+++ b/src/auth/get-permissions.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { getDalConnector } from '../dal/connector.js'
 import { permissionsQuery } from '../dal/queries/permissions-query.js'
 import { mapPermissions } from '../mappers/permissions-mapper.js'
@@ -18,7 +19,7 @@ const getPermissions = async (sbi, crn, forwardedUserToken) => {
     return mappedResponse
   }
 
-  return dalResponse
+  throw Boom.forbidden('Failed to retrieve permissions')
 }
 
 export { getPermissions }

--- a/src/config/dal.js
+++ b/src/config/dal.js
@@ -4,30 +4,35 @@ export const dalConfig = {
       doc: 'API endpoint to retrieve data from the data access layer (DAL)',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_ENDPOINT'
     },
     tenantId: {
       doc: 'Unique ID of the Azure Active Directory the application uses to sign in and get tokens',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_TENANT_ID'
     },
     tokenEndpoint: {
       doc: 'Token endpoint for retrieving an identity and authentication token for the Data Access Layer',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_TOKEN_ENDPOINT'
     },
     clientId: {
       doc: 'Client ID for authenticating with the DAL',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_CLIENT_ID'
     },
     clientSecret: {
       doc: 'Client secret for authentication with the DAL',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_CLIENT_SECRET',
       sensitive: true
     },
@@ -35,6 +40,7 @@ export const dalConfig = {
       doc: 'Email address of the customer',
       format: String,
       default: null,
+      nullable: true,
       env: 'DAL_EMAIL_HEADER'
     }
   }

--- a/src/config/os-places.js
+++ b/src/config/os-places.js
@@ -4,6 +4,7 @@ export const osPlacesConfig = {
       doc: 'Client ID for authenticating with OS Places',
       format: String,
       default: null,
+      nullable: true,
       env: 'OS_PLACES_CLIENT_ID'
     },
     osPlacesStub: {

--- a/src/dal/connector.js
+++ b/src/dal/connector.js
@@ -52,9 +52,13 @@ const buildDalRequest = (bearerToken, forwardedUserToken, graphqlQuery, variable
 const handleDalFailure = (err) => {
   logger.error(err, 'Error connecting to DAL')
 
+  const error = err instanceof Error
+    ? { message: err.message }
+    : { message: 'Error connecting to DAL' }
+
   return formatDalResponse({
     statusCode: httpConstants.HTTP_STATUS_INTERNAL_SERVER_ERROR,
-    errors: [err]
+    errors: [error]
   })
 }
 

--- a/src/routes/auth-routes.js
+++ b/src/routes/auth-routes.js
@@ -1,3 +1,4 @@
+import Boom from '@hapi/boom'
 import { getPermissions } from '../auth/get-permissions.js'
 import { getSignOutUrl } from '../auth/get-sign-out-url.js'
 import { validateState } from '../auth/state.js'
@@ -40,6 +41,10 @@ const signInOidc = {
     // These calls are authenticated using the token returned from Defra Identity
     const { sbi, crn, sessionId } = profile
     const { privileges, businessName } = await getPermissions(sbi, crn, token)
+
+    if (!privileges || !businessName) {
+      throw Boom.forbidden('Failed to retrieve permissions')
+    }
 
     const isOnFarmingPaymentsAllowList = allowListService(sbi, crn, 'farmingPayments')
 

--- a/src/services/business/fetch-business-details-service.js
+++ b/src/services/business/fetch-business-details-service.js
@@ -25,7 +25,7 @@ const fetchBusinessDetailsService = async (credentials) => {
     return mappedResponse
   }
 
-  return dalResponse
+  throw new Error('Failed to retrieve business details')
 }
 
 export {

--- a/src/services/fetch-personal-business-details-service.js
+++ b/src/services/fetch-personal-business-details-service.js
@@ -24,7 +24,7 @@ const fetchPersonalBusinessDetailsService = async (credentials) => {
     return mappedResponse
   }
 
-  return dalResponse
+  throw new Error('Failed to retrieve personal and business details')
 }
 
 export {

--- a/src/services/personal/fetch-personal-details-service.js
+++ b/src/services/personal/fetch-personal-details-service.js
@@ -26,7 +26,7 @@ const fetchPersonalDetailsService = async (credentials) => {
     return mappedResponse
   }
 
-  return dalResponse
+  throw new Error('Failed to retrieve personal details')
 }
 
 export {

--- a/test/integration/narrow/routes/auth-routes.test.js
+++ b/test/integration/narrow/routes/auth-routes.test.js
@@ -37,9 +37,6 @@ const credentials = {
   refreshToken: 'DEFRA-ID-REFRESH-TOKEN'
 }
 
-const role = 'Farmer'
-const scope = ['user']
-
 const signOutUrl = 'https://oidc.example.com/sign-out'
 
 const { createServer } = await import('../../../../src/server.js')
@@ -102,7 +99,10 @@ describe('auth routes', () => {
   describe('GET /auth/sign-in-oidc', () => {
     beforeEach(() => {
       path = '/auth/sign-in-oidc'
-      mockGetPermissions.mockResolvedValue({ role, scope })
+      mockGetPermissions.mockResolvedValue({
+        privileges: ['FARMER:FULL'],
+        businessName: 'Test Business'
+      })
     })
 
     test('redirects to oidc sign in page if unauthenticated', async () => {

--- a/test/unit/auth/get-permissions.test.js
+++ b/test/unit/auth/get-permissions.test.js
@@ -63,17 +63,25 @@ describe('getPermissions', () => {
 
     test('should not call mapPermissions when dalConnector response has no data', async () => {
       mockDalConnector.query.mockResolvedValue({})
-      await getPermissions(sbi, crn)
+      await expect(getPermissions(sbi, crn)).rejects.toThrowError('Failed to retrieve permissions')
 
       expect(mapPermissions).not.toHaveBeenCalled()
     })
 
-    test('should return dalConnector response when dalConnector response has no data', async () => {
+    test('should throw forbidden when dalConnector response has no data', async () => {
       const dalResponse = { response: 'no-dal-data' }
       mockDalConnector.query.mockResolvedValue(dalResponse)
-      const result = await getPermissions(sbi, crn)
+      await expect(getPermissions(sbi, crn)).rejects.toThrowError('Failed to retrieve permissions')
+    })
 
-      expect(result).toBe(dalResponse)
+    test('should throw forbidden when dalConnector returns errors', async () => {
+      mockDalConnector.query.mockResolvedValue({
+        data: null,
+        errors: [{ message: 'DAL failed' }],
+        statusCode: 500
+      })
+
+      await expect(getPermissions(sbi, crn)).rejects.toThrowError('Failed to retrieve permissions')
     })
 
     test('should pass through forwarded user token when provided', async () => {

--- a/test/unit/dal/connector.test.js
+++ b/test/unit/dal/connector.test.js
@@ -136,6 +136,33 @@ describe('DAL (data access layer) connector', () => {
       expect(result.errors[0].extensions.code).toBe('NOT_FOUND')
       expect(result.statusCode).toBe(404)
     })
+
+    test('should treat partial success responses as a failure', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: { business: { sbi: 123456789 } },
+          errors: [
+            {
+              message: 'Partial failure',
+              extensions: {
+                response: {
+                  status: 503
+                }
+              }
+            }
+          ]
+        })
+      })
+
+      const result = await dalConnector.query(exampleQuery, { sbi: 123456789 })
+
+      expect(result.data).toBeNull()
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].message).toBe('Partial failure')
+      expect(result.statusCode).toBe(503)
+    })
   })
 
   describe('when a network error occurs', () => {
@@ -144,6 +171,8 @@ describe('DAL (data access layer) connector', () => {
 
       const result = await dalConnector.query(exampleQuery, { sbi: 123456789 })
 
+      expect(result).toBeDefined()
+      expect(result.errors).toBeDefined()
       expect(result.data).toBeNull()
       expect(result.statusCode).toBe(500)
       expect(result.errors[0].message).toBe('Network error')

--- a/test/unit/routes/auth-routes.test.js
+++ b/test/unit/routes/auth-routes.test.js
@@ -1,5 +1,6 @@
 // Test framework dependencies
 import { vi, describe, beforeEach, test, expect } from 'vitest'
+import Boom from '@hapi/boom'
 
 // Things we need to mock
 import { getPermissions } from '../../../src/auth/get-permissions.js'
@@ -176,6 +177,48 @@ describe('auth', () => {
       await route.handler(mockRequest, mockH)
 
       expect(mockH.redirect).toHaveBeenCalledWith('/home')
+    })
+
+    test('handler should bubble forbidden error when getPermissions throws', async () => {
+      const mockH = { redirect: vi.fn() }
+      const mockRequest = createMockRequest()
+      getPermissions.mockRejectedValue(Boom.forbidden('Failed to retrieve permissions'))
+
+      await expect(route.handler(mockRequest, mockH)).rejects.toMatchObject({
+        isBoom: true,
+        output: {
+          statusCode: 403
+        }
+      })
+
+      expect(mockH.redirect).not.toHaveBeenCalled()
+    })
+
+    test('handler should throw forbidden when getPermissions returns invalid payload', async () => {
+      const mockH = { redirect: vi.fn() }
+      const mockCacheSet = vi.fn()
+      const mockRequest = createMockRequest({
+        server: {
+          app: {
+            cache: {
+              set: mockCacheSet,
+              get: vi.fn(),
+              drop: vi.fn()
+            }
+          }
+        }
+      })
+      getPermissions.mockResolvedValue({ privileges: undefined, businessName: undefined })
+
+      await expect(route.handler(mockRequest, mockH)).rejects.toMatchObject({
+        isBoom: true,
+        output: {
+          statusCode: 403
+        }
+      })
+
+      expect(mockCacheSet).not.toHaveBeenCalled()
+      expect(mockH.redirect).not.toHaveBeenCalled()
     })
   })
 

--- a/test/unit/routes/business/business-details-routes.test.js
+++ b/test/unit/routes/business/business-details-routes.test.js
@@ -100,6 +100,14 @@ describe('business details', () => {
           sectionsNeedingUpdate: ['name']
         })
       })
+
+      test('bubbles error when fetch service fails and does not render success view', async () => {
+        fetchBusinessDetailsService.mockRejectedValue(new Error('Failed to retrieve business details'))
+
+        await expect(getBusinessDetails.handler(request, h)).rejects.toThrowError('Failed to retrieve business details')
+
+        expect(h.view).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/test/unit/routes/personal/personal-details-routes.test.js
+++ b/test/unit/routes/personal/personal-details-routes.test.js
@@ -99,6 +99,14 @@ describe('personal details', () => {
         }
         )
       })
+
+      test('bubbles error when fetch service fails and does not render success view', async () => {
+        fetchPersonalDetailsService.mockRejectedValue(new Error('Failed to retrieve personal details'))
+
+        await expect(getPersonalDetails.handler(request, h)).rejects.toThrowError('Failed to retrieve personal details')
+
+        expect(h.view).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/test/unit/services/business/fetch-business-details-service.test.js
+++ b/test/unit/services/business/fetch-business-details-service.test.js
@@ -76,7 +76,7 @@ describe('fetchBusinessDetailsService', () => {
       expect(result).toEqual(getMappedData())
     })
 
-    test('should return raw DAL response when data is missing', async () => {
+    test('should throw when DAL response contains errors', async () => {
       const errorResponse = {
         data: null,
         errors: [{ message: 'error response from dal' }],
@@ -84,12 +84,10 @@ describe('fetchBusinessDetailsService', () => {
       }
       mockDalConnector.query.mockResolvedValue(errorResponse)
 
-      const result = await fetchBusinessDetailsService(credentials)
+      await expect(fetchBusinessDetailsService(credentials))
+        .rejects.toThrowError('Failed to retrieve business details')
 
       expect(mockMapBusinessDetails).not.toHaveBeenCalled()
-      expect(result).toEqual(errorResponse)
-      expect(result.errors).toBeDefined()
-      expect(result.statusCode).toBe(500)
     })
   })
 
@@ -120,7 +118,7 @@ describe('fetchBusinessDetailsService', () => {
       expect(result).toEqual(getMappedData())
     })
 
-    test('should return raw DAL response when data is missing', async () => {
+    test('should throw when DAL response contains errors', async () => {
       const errorResponse = {
         data: null,
         errors: [{ message: 'error response from dal' }],
@@ -128,12 +126,10 @@ describe('fetchBusinessDetailsService', () => {
       }
       mockDalConnector.query.mockResolvedValue(errorResponse)
 
-      const result = await fetchBusinessDetailsService(credentials)
+      await expect(fetchBusinessDetailsService(credentials))
+        .rejects.toThrowError('Failed to retrieve business details')
 
       expect(mockMapBusinessDetails).not.toHaveBeenCalled()
-      expect(result).toEqual(errorResponse)
-      expect(result.errors).toBeDefined()
-      expect(result.statusCode).toBe(500)
     })
   })
 })

--- a/test/unit/services/fetch-personal-business-details-service.test.js
+++ b/test/unit/services/fetch-personal-business-details-service.test.js
@@ -61,19 +61,17 @@ describe('fetchPersonalBusinessDetailsService', () => {
       expect(result).toMatchObject(mappedDalData)
     })
 
-    test('returns raw DAL response when data is missing', async () => {
+    test('throws when DAL response contains errors', async () => {
       const dalErrorResponse = {
         data: null,
         errors: [{ message: 'error response from dal' }],
         statusCode: 500
       }
       mockDalConnector.query.mockResolvedValue(dalErrorResponse)
-      const result = await fetchPersonalBusinessDetailsService(credentials)
+      await expect(fetchPersonalBusinessDetailsService(credentials))
+        .rejects.toThrowError('Failed to retrieve personal and business details')
 
       expect(mockMappedValue).not.toHaveBeenCalled()
-      expect(result).toMatchObject(dalErrorResponse)
-      expect(result.errors).toBeDefined()
-      expect(result.statusCode).toBe(500)
     })
   })
 })

--- a/test/unit/services/personal/fetch-personal-details-service.test.js
+++ b/test/unit/services/personal/fetch-personal-details-service.test.js
@@ -61,19 +61,17 @@ describe('fetchPersonalDetailsService', () => {
       expect(result).toMatchObject(mappedDalData)
     })
 
-    test('returns raw DAL response when data is missing', async () => {
+    test('throws when DAL response contains errors', async () => {
       const dalErrorResponse = {
         data: null,
         errors: [{ message: 'error response from dal' }],
         statusCode: 500
       }
       mockDalConnector.query.mockResolvedValue(dalErrorResponse)
-      const result = await fetchPersonalDetailsService(credentials)
+      await expect(fetchPersonalDetailsService(credentials))
+        .rejects.toThrowError('Failed to retrieve personal details')
 
       expect(mockMappedValue).not.toHaveBeenCalled()
-      expect(result).toMatchObject(dalErrorResponse)
-      expect(result.errors).toBeDefined()
-      expect(result.statusCode).toBe(500)
     })
   })
 })


### PR DESCRIPTION
# Description

The DAL connector's catch path could return undefined rather than a structured error object, meaning failures were silently swallowed downstream. In the auth flow if `getPermissions` failed, `undefined` values for `scope` and `businessName` could be written straight into the session cache, leaving the session in a corrupt state.

# Changes

- Harden connector catch path to always return structured error object,
  never `undefined` (addresses John's review comment on undefined masking root cause)
- Throw `Boom.forbidden` in `getPermissions` when DAL returns no data or errors
- Guard auth route against undefined privileges/businessName before `cache.set`
- Throw sanitized errors from business, personal, and combined detail services
- Add `nullable: true` to optional DAL and OS Places config fields for Docker test env
- Update unit and integration tests to assert error-throwing behaviour
- Fix integration test mock for `getPermissions` to return correct shape

Confirm each of the checklist points has been completed as part of the review process.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintainable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity