### PR TITLE
add example metrics counter

### DIFF
--- a/src/routes/home-routes.js
+++ b/src/routes/home-routes.js
@@ -1,5 +1,6 @@
 import { homePresenter } from '../presenters/home-presenter.js'
 import { fetchPersonalBusinessDetailsService } from '../services/fetch-personal-business-details-service.js'
+import { metricsCounter } from '../utils/metrics.js'
 
 const index = {
   method: 'GET',
@@ -21,6 +22,8 @@ const home = {
     const isOnFarmingPaymentsAllowList = yar.get('isOnFarmingPaymentsAllowList')
     const data = await fetchPersonalBusinessDetailsService(auth.credentials)
     const pageData = homePresenter(data, auth.credentials.scope, auth.credentials.enrolmentCount, isOnFarmingPaymentsAllowList)
+
+    await metricsCounter('users.active')
 
     return h.view('home', pageData)
   }

--- a/test/unit/routes/home-routes.test.js
+++ b/test/unit/routes/home-routes.test.js
@@ -4,6 +4,7 @@ import { vi, beforeEach, describe, test, expect } from 'vitest'
 // Things we need to mock
 import { fetchPersonalBusinessDetailsService } from '../../../src/services/fetch-personal-business-details-service.js'
 import { homePresenter } from '../../../src/presenters/home-presenter.js'
+import { metricsCounter } from '../../../src/utils/metrics.js'
 
 // Thing under test
 import { homeRoutes } from '../../../src/routes/home-routes.js'
@@ -16,6 +17,10 @@ vi.mock('../../../src/services/fetch-personal-business-details-service.js', () =
 
 vi.mock('../../../src/presenters/home-presenter.js', () => ({
   homePresenter: vi.fn()
+}))
+
+vi.mock('../../../src/utils/metrics.js', () => ({
+  metricsCounter: vi.fn()
 }))
 
 describe('Root endpoint', () => {
@@ -86,6 +91,7 @@ describe('Home endpoint', () => {
 
         expect(fetchPersonalBusinessDetailsService).toHaveBeenCalledWith(request.auth.credentials)
         expect(homePresenter).toHaveBeenCalledWith(getMockData(), request.auth.credentials.scope, request.auth.credentials.enrolmentCount, true)
+        expect(metricsCounter).toHaveBeenCalledWith('users.active')
         expect(h.view).toHaveBeenCalledWith('home', pageData)
       })
     })


### PR DESCRIPTION
# Overview

Instruments the home route with an active users metric by calling `metricsCounter('users.active')` on each successful page load, feeding data into the [Grafana request-handling dashboard](https://metrics.dev.cdp-int.defra.cloud/d/f4481c9f-9a90-4467-9dc9-f25660746194/fcp-sfd-frontend-request-handling-dashboard?orgId=1&from=now-24h&to=now&timezone=browser).

## Changes

### `src/routes/home-routes.js`
- Imports `metricsCounter` from `../utils/metrics.js`
- Calls `metricsCounter('users.active')` in the home route handler after the page data is prepared, before returning the view

### `test/unit/routes/home-routes.test.js`
- Adds a mock for `metricsCounter`
- Asserts that `metricsCounter` is called with `'users.active'` when the home route handler executes successfully