### PR TITLE
SFD2-1056: Reduce local MongoDB log noise in Docker Compose

### DIFF
--- a/compose.debug.yaml
+++ b/compose.debug.yaml
@@ -1,3 +1,6 @@
 services:
   fcp-sfd-frontend:
     command: npm run start:debug
+  mongo:
+    attach: true
+    command: null

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -37,6 +37,10 @@ services:
   mongo:
     networks:
       - fcp-sfd
+    attach: false
+    command: ["--quiet"]
+    logging:
+      driver: "none"
 
 networks:
   fcp-sfd:

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -39,8 +39,6 @@ services:
       - fcp-sfd
     attach: false
     command: ["--quiet"]
-    logging:
-      driver: "none"
 
 networks:
   fcp-sfd:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:scss": "stylelint \"src/**/*.scss\" --cache --cache-location .cache/stylelint --cache-strategy content --color --ignore-path .gitignore",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
     "pretest": "npm run test:lint",
-    "docker:debug": "docker compose -f compose.yaml -f compose.debug.yaml -p \"fcp-sfd-frontend\" up",
+    "docker:debug": "docker compose -f compose.yaml -f compose.override.yaml -f compose.debug.yaml -p \"fcp-sfd-frontend\" up",
     "docker:dev": "docker compose up",
     "docker:test": "npm run lint && mkdir -p coverage 2>/dev/null || true docker compose -p fcp-sfd-frontend-test down -v && docker compose -f compose.yaml -f compose.test.yaml -p fcp-sfd-frontend-test run --build --rm fcp-sfd-frontend",
     "docker:test:watch": "docker compose -p fcp-sfd-frontend-test down -v && docker compose -f compose.yaml -f compose.test.yaml -f compose.test.watch.yaml -p fcp-sfd-frontend-test run --build --rm fcp-sfd-frontend",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-1056

## Summary
Reduce local MongoDB log noise so normal `docker compose up` output is easier to scan for frontend and DAL logs, while keeping an opt-in debug mode that re-enables Mongo visibility when needed.

## Changes
- Updated `compose.override.yaml` to keep Mongo quiet in normal local runs:
  - `attach: false`
  - `command: ["--quiet"]`
- Updated `compose.debug.yaml` to re-enable Mongo visibility in debug mode:
  - `mongo.attach: true`
  - `mongo.command: null`
- Updated `docker:debug` in `package.json` to layer `compose.yaml`, `compose.override.yaml`, and `compose.debug.yaml` so debug mode builds on local defaults and then applies debug overrides.