### PR TITLE
chore: exclude dependabot from sonarqube scan

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -44,6 +44,7 @@ jobs:
           docker compose -f compose.yaml -f compose.test.yaml run --rm "fcp-sfd-frontend"
 
       - name: SonarCloud Scan
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This Pull Request excludes PRs created by dependabot from running sonarqube as this requires a token to which the bot does not have access.

This follows https://github.com/DEFRA/cdp-node-frontend-template/blob/main/.github/workflows/check-pull-request.yml