### PR TITLE
Dependabot/docker compose/defradigital/fcp dal api 2.2.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ This document provides essential information to help Copilot assist effectively 
 - **Debug:** `npm run docker:debug` - Docker stack with debug configuration
 
 ### Local Testing Note
-Vitest tests run locally without Docker. Docker tests (`npm run docker:test`) require the full Docker Compose stack (includes DAL API and kits-mock services) because the code integrates with the Data Access Layer (DAL).
+Vitest tests run locally without Docker. Docker tests (`npm run docker:test`) require the full Docker Compose stack (includes DAL API and upstream-mock services) because the code integrates with the Data Access Layer (DAL).
 
 ---
 

--- a/compose.kits-local.yaml
+++ b/compose.kits-local.yaml
@@ -2,7 +2,7 @@ services:
   fcp-sfd-frontend:
     environment:
       DAL_ENDPOINT: http://fcp-dal-api:3005/graphql
-  kits-mock:
+  upstream-mock:
     image: fcp-dal-upstream-mock:local
     build:
       context: ${DAL_UPSTREAM_MOCK_LOCAL_PATH}
@@ -10,4 +10,4 @@ services:
     command: ["node", "src"]
   fcp-dal-api:
     environment:
-      KITS_GATEWAY_INTERNAL_URL: http://kits-mock:3100/extapi/
+      KITS_GATEWAY_INTERNAL_URL: http://upstream-mock:3100/extapi/

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,7 +10,7 @@ services:
       - ./src:/home/node/src
       - ./package.json:/home/node/package.json
 
-  kits-mock:
+  upstream-mock:
     ports:
       - '3100:3100'
     networks:

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -23,8 +23,8 @@ services:
     depends_on:
       fcp-dal-api:
         condition: service_started
-      kits-mock:
-        condition: service_started
+      upstream-mock:
+        condition: service_healthy
     volumes:
       - ./src/:/home/node/src
       - ./test/:/home/node/test

--- a/compose.yaml
+++ b/compose.yaml
@@ -47,7 +47,7 @@ services:
 
 
   fcp-dal-api:
-    image: defradigital/fcp-dal-api:0.116.0
+    image: defradigital/fcp-dal-api:2.2.1
     depends_on:
       - kits-mock
       - mongo

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
       WOODLAND_MANAGEMENT_ALLOWED_SBIS: ${WOODLAND_MANAGEMENT_ALLOWED_SBIS}
       WMP_ENDPOINT: ${WMP_ENDPOINT:-https://grants-ui.test.cdp-int.defra.cloud/woodland}
 
-  kits-mock:
+  upstream-mock:
     image: defradigital/fcp-dal-upstream-mock:0.77.0
     environment:
       MOCK_LOG_LEVEL: info
@@ -44,13 +44,21 @@ services:
       NODE_ENV: development
       PORT: 3100
       KIT_EXT_PERSON_ID_OVERRIDE: 3000000
-
+    ports:
+      - '3100:3100'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:3100/health']
+      interval: 3s
+      timeout: 2s
+      retries: 5
 
   fcp-dal-api:
     image: defradigital/fcp-dal-api:2.2.1
     depends_on:
-      - kits-mock
-      - mongo
+      upstream-mock: 
+        condition: service_healthy
+      mongo:
+        condition: service_started
     environment:
       ALL_SCHEMA_ON: true
       LOG_LEVEL: info
@@ -58,14 +66,17 @@ services:
       PORT: 3005
       ENVIRONMENT: dev
       DISABLE_AUTH: true
+      HITACHI_DISABLE_AUTH: true
       DISABLE_PROXY: true
       GRAPHQL_DASHBOARD_ENABLED: true
       ADMIN_AD_GROUP_ID: unused
-      KITS_INTERNAL_GATEWAY_URL: http://kits-mock:3100/extapi/
-      KITS_EXTERNAL_GATEWAY_URL: http://kits-mock:3100/extapi/
+      KITS_INTERNAL_GATEWAY_URL: http://upstream-mock:3100/extapi/
+      KITS_EXTERNAL_GATEWAY_URL: http://upstream-mock:3100/extapi/
       KIT_EXT_PERSON_ID_OVERRIDE: 3000000
       KITS_GATEWAY_TIMEOUT_MS: 3000
       KITS_DISABLE_MTLS: true
+      HITACHI_GATEWAY_URL: http://upstream-mock:3100/api/
+      HITACHI_TIMEOUT_MS: 3000
       MONGO_URI: mongodb://mongo:27017
       DAL_REQUEST_TIMEOUT_MS: 3000
 


### PR DESCRIPTION
This PR replicates some of the changes implemented by dal-api's latest version:
https://github.com/DEFRA/fcp-dal-api/commit/9c7bbb211f0d68e55649d2d91abdced943d024fd 

with regards to Hitachi authentication for tests.

I took the opportunity to also apply some of the other naming changes for reducing the drift between the two composes