### PR TITLE
SFD2-1006: Disable Redis ready check to prevent NOPERM warnings in CDP

### DIFF
--- a/src/utils/caching/redis-client.js
+++ b/src/utils/caching/redis-client.js
@@ -25,6 +25,7 @@ export const buildRedisClient = (redisConfig) => {
       host,
       db,
       keyPrefix,
+      enableReadyCheck: false,
       ...credentials,
       ...tls
     })
@@ -42,6 +43,7 @@ export const buildRedisClient = (redisConfig) => {
         dnsLookup: (address, callback) => callback(null, address),
         redisOptions: {
           db,
+          enableReadyCheck: false,
           ...credentials,
           ...tls
         }

--- a/test/unit/utils/caching/redis-client.test.js
+++ b/test/unit/utils/caching/redis-client.test.js
@@ -66,7 +66,8 @@ describe('buildRedisClient', () => {
       port: 6379,
       host: 'localhost',
       db: 0,
-      keyPrefix: 'test:'
+      keyPrefix: 'test:',
+      enableReadyCheck: false
     })
     expect(Cluster).not.toHaveBeenCalled()
     expect(createLogger).toHaveBeenCalled()
@@ -91,7 +92,7 @@ describe('buildRedisClient', () => {
         keyPrefix: 'test:',
         slotsRefreshTimeout: 10000,
         dnsLookup: expect.any(Function),
-        redisOptions: { db: 0 }
+        redisOptions: { db: 0, enableReadyCheck: false }
       }
     )
     expect(Redis).not.toHaveBeenCalled()
@@ -116,6 +117,7 @@ describe('buildRedisClient', () => {
       host: 'localhost',
       db: 0,
       keyPrefix: 'test:',
+      enableReadyCheck: false,
       username: 'user',
       password: 'pass'
     })
@@ -138,6 +140,7 @@ describe('buildRedisClient', () => {
       host: 'localhost',
       db: 0,
       keyPrefix: 'test:',
+      enableReadyCheck: false,
       tls: {}
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SFD2-1006

## Summary

In CDP environments, ioredis performs a ready check on startup by issuing a Redis `INFO` command. The Redis user provisioned in CDP does not have permission to run `INFO`, causing `NOPERM` warnings in the logs on every connection. These warnings are noise — they do not indicate a real connectivity problem — but they clutter logs and can mask genuine issues. Disabling `enableReadyCheck` suppresses the warnings without affecting connectivity or session handling.

## Changes

- Set `enableReadyCheck: false` on both single-instance (`Redis`) and cluster (`Cluster`) ioredis configurations in `src/utils/caching/redis-client.js`
- Updated unit tests to assert the new option is present in all connection mode scenarios