### PR TITLE
FLS2-18 Remove DAL email header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ DAL_TOKEN_ENDPOINT=https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/tok
 DAL_CLIENT_ID=long-value-full-of-numbers-and-letters-in-lowercase
 DAL_CLIENT_SECRET=longvaluefullofnumbersandlettersandsymbols
 DAL_TENANT_ID=long-value-full-of-numbers-and-letters-in-lowercase
-DAL_EMAIL_HEADER=testuser11@defra.gov.uk
 
 # DEFRA ID config
 DEFRA_ID_WELL_KNOWN_URL=https://defra-id.well.known/url

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,6 @@ services:
       DEFRA_ID_POLICY: ${DEFRA_ID_POLICY}
       DEFRA_ID_REDIRECT_URL: http://localhost:3000/auth/sign-in-oidc
       DEFRA_ID_SIGN_OUT_REDIRECT_URL: http://localhost:3000/auth/sign-out-oidc
-      DAL_EMAIL_HEADER: ${DAL_EMAIL_HEADER}
       OS_PLACES_CLIENT_ID: ${OS_PLACES_CLIENT_ID}
       OS_PLACES_STUB: ${OS_PLACES_STUB:-false}
       PERSONAL_DETAILS_INTERRUPTER_ENABLED: ${PERSONAL_DETAILS_INTERRUPTER_ENABLED:-false}
@@ -55,7 +54,7 @@ services:
   fcp-dal-api:
     image: defradigital/fcp-dal-api:2.2.1
     depends_on:
-      upstream-mock: 
+      upstream-mock:
         condition: service_healthy
       mongo:
         condition: service_started

--- a/src/config/dal.js
+++ b/src/config/dal.js
@@ -35,13 +35,6 @@ export const dalConfig = {
       nullable: true,
       env: 'DAL_CLIENT_SECRET',
       sensitive: true
-    },
-    email: {
-      doc: 'Email address of the customer',
-      format: String,
-      default: null,
-      nullable: true,
-      env: 'DAL_EMAIL_HEADER'
     }
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-18

Since removing the dal stub the DAL_EMAIL_HEADER config remains in the repo. This PR is to remove this redundant config.