### PR TITLE
Add Dependency Review Action to PR Checks

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -48,3 +48,9 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: always


### PR DESCRIPTION
## Summary

Adds the [GitHub Dependency Review Action](https://github.com/actions/dependency-review-action) to the PR check workflow. This surfaces known vulnerabilities in dependency changes before they are merged, catching supply-chain risks early in the review process.

## Changes

- Add `actions/dependency-review-action@v4` step to `check-pull-request.yml`
- Configured to fail on `moderate` or higher severity
- Always posts a summary comment on the PR

## Notes

- This action only runs on `pull_request` events and scans the diff between base and head, so it will not flag existing dependencies — only newly introduced ones.