### PR TITLE
Add local engine dev workflow via compose volume override

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `fcp-sfd-frontend-engine` repository must be cloned as a sibling of this one
    ```
    The overlay mounts the engine's local `dist/` and `package.json` into the container and configures nodemon to restart the server whenever the engine rebuilds.
 
-> **Note:** VS Code tasks for both of the above steps are provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **"🔨 Watch Engine"** and **"🔗 Up Frontend with local Engine"** tasks.
+> **Note:** VS Code tasks for both of the above steps are provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **"🔨 Watch and Rebuild Engine"** and **"🔗 Up Frontend with local Engine"** tasks.
 
 ## Server-side Caching
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ Or to run the tests in watch mode:
 npm run docker:test:watch
 ```
 
+## Local engine development
+
+If you are working on [`fcp-sfd-frontend-engine`](https://github.com/DEFRA/fcp-sfd-frontend-engine) alongside this service, you can mount your local engine build directly into the container without changing `package.json`.
+
+### Prerequisites
+
+The `fcp-sfd-frontend-engine` repository must be cloned as a sibling of this one (i.e. both under the same parent directory).
+
+### Workflow
+
+1. In the engine repo, start the TypeScript watch build:
+   ```
+   npx tsup --watch
+   ```
+   This continuously rebuilds the engine `dist/` folder when source files change.
+
+2. Start this service using the engine overlay:
+   ```
+   docker compose -f compose.yaml -f compose.override.yaml -f compose.link-engine.yaml up --build
+   ```
+   The overlay mounts the engine's local `dist/` and `package.json` into the container and configures nodemon to restart the server whenever the engine rebuilds.
+
+> **Note:** VS Code tasks for both of the above steps are provided by [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment) — see the **"🔨 Watch Engine"** and **"🔗 Up Frontend with local Engine"** tasks.
+
 ## Server-side Caching
 
 We use Catbox for server-side caching. By default, the service will use CatboxRedis when deployed and CatboxMemory for local development. You can override the default behavior by setting the `SESSION_CACHE_ENGINE` environment variable to either `redis` or `memory`.

--- a/compose.link-engine.yaml
+++ b/compose.link-engine.yaml
@@ -1,3 +1,6 @@
+# NOTE: The fcp-sfd-frontend-engine repo must be pre-built before starting.
+# Run `npx tsup` (or use the Watch Engine task) in the engine repo first,
+# otherwise the mounted dist/ volume will be empty and the app will fail to start.
 services:
   fcp-sfd-frontend:
     command: npm run dev:link-engine

--- a/compose.link-engine.yaml
+++ b/compose.link-engine.yaml
@@ -1,0 +1,7 @@
+services:
+  fcp-sfd-frontend:
+    command: npm run dev:link-engine
+    volumes:
+      - ./nodemon.link-engine.json:/home/node/nodemon.link-engine.json
+      - ../fcp-sfd-frontend-engine/dist:/home/node/node_modules/@defra/fcp-sfd-frontend-engine/dist
+      - ../fcp-sfd-frontend-engine/package.json:/home/node/node_modules/@defra/fcp-sfd-frontend-engine/package.json

--- a/nodemon.link-engine.json
+++ b/nodemon.link-engine.json
@@ -1,0 +1,10 @@
+{
+  "watch": ["./src", "./node_modules/@defra/fcp-sfd-frontend-engine/dist"],
+  "ext": "cjs,js,json,njk",
+  "ignoreRoot": [],
+  "ignore": ["**/*.test.*", "./src/client", "./node_modules/.cache"],
+  "env": {
+    "NODE_ENV": "development"
+  },
+  "signal": "SIGINT"
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "dev": "run-p frontend:watch server:watch",
+    "dev:link-engine": "run-p frontend:watch server:watch:link-engine",
     "dev:debug": "run-p frontend:watch server:debug",
     "frontend:watch": "NODE_ENV=development webpack --watch",
     "postinstall": "npm run build",
@@ -28,6 +29,7 @@
     "test:lint": "standard",
     "start:debug": "nodemon --watch src --exec 'node --experimental-vm-modules --inspect-brk=0.0.0.0 src/index.js'",
     "server:watch": "nodemon --inspect=0.0.0.0 --ext js,njk --legacy-watch src/index.js",
+    "server:watch:link-engine": "nodemon --config nodemon.link-engine.json --inspect=0.0.0.0 --legacy-watch src/index.js",
     "server:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch src/index.js",
     "prestart": "npm run build",
     "start": "NODE_ENV=production node --use-strict ."


### PR DESCRIPTION
## What

Introduces a local development workflow for working on `fcp-sfd-frontend-engine` and `fcp-sfd-frontend` simultaneously, without manually editing `package.json`.

## Why

Previously, developers had to manually switch the engine dependency from the published version to a `file:` path, reinstall, and remember to revert before committing — risking accidental commits of the local path.

## How

- `package.json` always points to the **published** engine version
- A new `compose.link-engine.yaml` file volume-mounts the local engine's built `dist/` and `package.json` over the installed package inside the container at runtime
- A new `nodemon.link-engine.json` config watches both `src/` and the engine `dist/` folder — overriding nodemon's default behaviour of ignoring `node_modules` — so the server **auto-restarts** when the engine rebuilds
- VS Code tasks (**"🔗 Up Frontend with local Engine"** and **"🔨 Watch Engine"**) are provided via [`fcp-sfd-dev-environment`](https://github.com/DEFRA/fcp-sfd-dev-environment)

## Usage

**Normal development** (published engine): run "⬆️ Up Frontend" as before — no change.

**Developing engine + frontend simultaneously**:
1. Start **"🔨 Watch Engine"** task — runs `npx tsup --watch` in the engine repo, continuously rebuilding `dist/` on source changes
2. Start **"🔗 Up Frontend with local Engine"** task — mounts the local engine and starts the server with hot-reload enabled
3. Edit engine source → `dist/` rebuilds automatically → server restarts automatically

## Changes

- `compose.link-engine.yaml` — compose override that mounts local engine and sets the `dev:link-engine` command
- `nodemon.link-engine.json` — nodemon config enabling watch inside `node_modules`
- `package.json` — adds `dev:link-engine` and `server:watch:link-engine` scripts
- `README.md` — new "Local engine development" section documenting the workflow