### PR TITLE
Remove address and customer name mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.2.10",
+        "@defra/fcp-sfd-frontend-engine": "0.2.11",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -335,9 +335,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.10.tgz",
-      "integrity": "sha512-p07pUKi9gccsD6Nr6+aE6SHAuYf8IavwACRTj4Gr7KzifpM2isky5Q7e03U/ERgACIPbJ9Mad2Zvm+uggoAwug==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.11.tgz",
+      "integrity": "sha512-Ya4hpEvPtb2uraQ3+OIsKUoQs7hbrKqk90sNuWd0zXt+IqWdBMYKspc2OKA6HivePxXXdPLbnb6e7T2C+7eObQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.2.4",
+        "@defra/fcp-sfd-frontend-engine": "0.2.10",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -335,12 +335,48 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.4.tgz",
-      "integrity": "sha512-nsfl8vRZdCSXVLtbEsl6XrKRmTm9nmREnRNSsksaasRcGiw08ZaWLlcLfPYWCVf3GFWWo4bcmAajelg2gaLsfQ==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.2.10.tgz",
+      "integrity": "sha512-p07pUKi9gccsD6Nr6+aE6SHAuYf8IavwACRTj4Gr7KzifpM2isky5Q7e03U/ERgACIPbJ9Mad2Zvm+uggoAwug==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "joi": "17.13.3"
+        "joi": "18.2.1"
+      }
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@defra/fcp-sfd-frontend-engine/node_modules/joi": {
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@defra/hapi-tracing": {
@@ -1026,6 +1062,15 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.1.tgz",
       "integrity": "sha512-52OXRslUfYwXAOG8k58f2h2ngXYQGP0x5RPOo+eWA/FtyLgHjGMrE3+e9LSXP/0q2YfHAK5wj9aA9DTy1K+kyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14.0.0"
@@ -1987,7 +2032,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.2.10",
+    "@defra/fcp-sfd-frontend-engine": "0.2.11",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.2.4",
+    "@defra/fcp-sfd-frontend-engine": "0.2.10",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/mappers/business-details-mapper.js
+++ b/src/mappers/business-details-mapper.js
@@ -6,6 +6,8 @@
  * @returns {Object} Formatted business details data
  */
 
+import { mappers } from '@defra/fcp-sfd-frontend-engine'
+
 export const mapBusinessDetails = (value) => {
   return {
     info: {
@@ -18,39 +20,12 @@ export const mapBusinessDetails = (value) => {
       type: value.business.info.type.type,
       countyParishHoldingNumbers: value.business.countyParishHoldings
     },
-    address: {
-      lookup: {
-        pafOrganisationName: value.business.info.address.pafOrganisationName,
-        buildingNumberRange: value.business.info.address.buildingNumberRange,
-        flatName: value.business.info.address.flatName,
-        buildingName: value.business.info.address.buildingName,
-        dependentLocality: value.business.info.address.dependentLocality,
-        doubleDependentLocality: value.business.info.address.doubleDependentLocality,
-        street: value.business.info.address.street,
-        county: value.business.info.address.county,
-        uprn: value.business.info.address.uprn
-      },
-      manual: {
-        line1: value.business.info.address.line1,
-        line2: value.business.info.address.line2,
-        line3: value.business.info.address.line3,
-        line4: value.business.info.address.line4,
-        line5: value.business.info.address.line5
-      },
-      city: value.business.info.address.city,
-      postcode: value.business.info.address.postalCode,
-      country: value.business.info.address.country
-    },
+    address: mappers.address(value.business.info.address),
     contact: {
       email: value.business.info.email.address,
       landline: value.business.info.phone.landline ?? null,
       mobile: value.business.info.phone.mobile ?? null
     },
-    customer: {
-      userName: [
-        value.customer.info.name.first,
-        value.customer.info.name.last
-      ].filter(Boolean).join(' ')
-    }
+    customer: mappers.customerName(value.customer.info.name)
   }
 }

--- a/src/mappers/personal-details-mapper.js
+++ b/src/mappers/personal-details-mapper.js
@@ -5,16 +5,15 @@
  * @returns {Object} Formatted personal details data
  */
 
+import { mappers } from '@defra/fcp-sfd-frontend-engine'
+
 export const mapPersonalDetails = (value) => {
   const [year, month, day] = value.customer.info.dateOfBirth ? value.customer.info.dateOfBirth.split('-') : []
 
   return {
     crn: value.customer.crn,
     info: {
-      userName: [
-        value.customer.info.name.first,
-        value.customer.info.name.last
-      ].filter(Boolean).join(' '),
+      userName: mappers.customerName(value.customer.info.name),
       fullName: {
         first: value.customer.info.name.first,
         last: value.customer.info.name.last,
@@ -32,29 +31,7 @@ export const mapPersonalDetails = (value) => {
         year: year ?? null
       }
     },
-    address: {
-      lookup: {
-        pafOrganisationName: value.customer.info.address.pafOrganisationName,
-        buildingNumberRange: value.customer.info.address.buildingNumberRange,
-        flatName: value.customer.info.address.flatName,
-        buildingName: value.customer.info.address.buildingName,
-        dependentLocality: value.customer.info.address.dependentLocality,
-        doubleDependentLocality: value.customer.info.address.doubleDependentLocality,
-        street: value.customer.info.address.street,
-        county: value.customer.info.address.county,
-        uprn: value.customer.info.address.uprn
-      },
-      manual: {
-        line1: value.customer.info.address.line1,
-        line2: value.customer.info.address.line2,
-        line3: value.customer.info.address.line3,
-        line4: value.customer.info.address.line4,
-        line5: value.customer.info.address.line5
-      },
-      city: value.customer.info.address.city,
-      postcode: value.customer.info.address.postalCode,
-      country: value.customer.info.address.country
-    },
+    address: mappers.address(value.customer.info.address),
     contact: {
       email: value.customer.info.email.address,
       telephone: value.customer.info.phone.landline ?? null,

--- a/src/mappers/personal-details-mapper.js
+++ b/src/mappers/personal-details-mapper.js
@@ -13,7 +13,7 @@ export const mapPersonalDetails = (value) => {
   return {
     crn: value.customer.crn,
     info: {
-      userName: mappers.customerName(value.customer.info.name),
+      userName: mappers.customerName(value.customer.info.name).userName,
       fullName: {
         first: value.customer.info.name.first,
         last: value.customer.info.name.last,

--- a/test/unit/mappers/business-details-mapper.test.js
+++ b/test/unit/mappers/business-details-mapper.test.js
@@ -24,30 +24,19 @@ describe('businessDetailsMapper', () => {
     })
 
     describe('customer.userName', () => {
+      beforeEach(() => {
+        dalData.customer.info.name = {
+          first: 'Software',
+          last: 'Developer',
+          middle: null
+        }
+      })
+
       test('it should build the userName correctly', () => {
-        const result = mapBusinessDetails(
-          dalWithName(dalData, { first: 'Software', last: 'Developer' })
-        )
+        const result = mapBusinessDetails(dalData)
 
         expect(result.customer.userName).toEqual('Software Developer')
       })
     })
   })
 })
-
-const dalWithName = (base, name) => {
-  return {
-    ...base,
-    customer: {
-      ...base.customer,
-      info: {
-        ...base.customer.info,
-        name: {
-          first: name.first,
-          last: name.last,
-          middle: name.middle ?? null
-        }
-      }
-    }
-  }
-}

--- a/test/unit/mappers/personal-details-mapper.test.js
+++ b/test/unit/mappers/personal-details-mapper.test.js
@@ -24,20 +24,32 @@ describe('personalDetailsMapper', () => {
     })
 
     describe('info.userName', () => {
+      beforeEach(() => {
+        dalData.customer.info.name = {
+          first: 'Software',
+          last: 'Developer',
+          middle: null
+        }
+      })
+
       test('it should build the userName correctly', () => {
-        const result = mapPersonalDetails(
-          dalWithName(dalData, { first: 'Software', last: 'Developer', middle: null })
-        )
+        const result = mapPersonalDetails(dalData)
 
         expect(result.info.userName).toEqual('Software Developer')
       })
     })
 
     describe('info.fullName', () => {
+      beforeEach(() => {
+        dalData.customer.info.name = {
+          first: 'Software',
+          last: 'Developer',
+          middle: 'Engineer'
+        }
+      })
+
       test('it should build the fullName object correctly', () => {
-        const result = mapPersonalDetails(
-          dalWithName(dalData, { first: 'Software', last: 'Developer', middle: 'Engineer' })
-        )
+        const result = mapPersonalDetails(dalData)
 
         expect(result.info.fullName).toEqual({
           first: 'Software',
@@ -48,67 +60,55 @@ describe('personalDetailsMapper', () => {
     })
 
     describe('info.fullNameJoined', () => {
+      beforeEach(() => {
+        dalData.customer.info.name = {
+          first: 'Software',
+          last: 'Developer',
+          middle: 'Engineer'
+        }
+      })
+
       test('it should build the fullNameJoined string correctly', () => {
-        const result = mapPersonalDetails(
-          dalWithName(dalData, { first: 'Software', last: 'Developer', middle: 'Engineer' })
-        )
+        const result = mapPersonalDetails(dalData)
 
         expect(result.info.fullNameJoined).toEqual('Software Engineer Developer')
       })
     })
 
     describe('info.dateOfBirth', () => {
-      test('it should build the date of birth correctly when it exists', () => {
-        const result = mapPersonalDetails(dalWithDateOfBirth(dalData, '1990-01-01'))
+      describe('when date of birth exists', () => {
+        beforeEach(() => {
+          dalData.customer.info.dateOfBirth = '1990-01-01'
+        })
 
-        expect(result.info.dateOfBirth).toEqual({
-          full: '1990-01-01',
-          day: '01',
-          month: '01',
-          year: '1990'
+        test('it should build the date of birth correctly when it exists', () => {
+          const result = mapPersonalDetails(dalData)
+
+          expect(result.info.dateOfBirth).toEqual({
+            full: '1990-01-01',
+            day: '01',
+            month: '01',
+            year: '1990'
+          })
         })
       })
 
-      test('it should build the date of birth correctly when it does not exist', () => {
-        const result = mapPersonalDetails(dalWithDateOfBirth(dalData, null))
+      describe('when date of birth does not exist', () => {
+        beforeEach(() => {
+          dalData.customer.info.dateOfBirth = null
+        })
 
-        expect(result.info.dateOfBirth).toEqual({
-          full: null,
-          day: null,
-          month: null,
-          year: null
+        test('it should build the date of birth correctly when it does not exist', () => {
+          const result = mapPersonalDetails(dalData)
+
+          expect(result.info.dateOfBirth).toEqual({
+            full: null,
+            day: null,
+            month: null,
+            year: null
+          })
         })
       })
     })
   })
 })
-
-const dalWithName = (base, name) => {
-  return {
-    ...base,
-    customer: {
-      ...base.customer,
-      info: {
-        ...base.customer.info,
-        name: {
-          first: name.first,
-          last: name.last,
-          middle: name.middle ?? null
-        }
-      }
-    }
-  }
-}
-
-const dalWithDateOfBirth = (base, value) => {
-  return {
-    ...base,
-    customer: {
-      ...base.customer,
-      info: {
-        ...base.customer.info,
-        dateOfBirth: value
-      }
-    }
-  }
-}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-97

As part of the work to deduplicate the internal and external frontend, two of the mappers (address and customer name) have been moved into the engine. 
This PR is pulling these mappers out of the external repo and using the engine ones instead. 