### PR TITLE
Fix personal business details mapper

### DIFF
--- a/src/services/fetch-personal-business-details-service.js
+++ b/src/services/fetch-personal-business-details-service.js
@@ -19,7 +19,7 @@ const fetchPersonalBusinessDetailsService = async (credentials) => {
   )
 
   if (dalResponse.data) {
-    const mappedResponse = mappers.mapPersonalBusinessDetails(dalResponse.data)
+    const mappedResponse = mappers.personalBusinessDetails(dalResponse.data)
 
     return mappedResponse
   }

--- a/test/unit/services/fetch-personal-business-details-service.test.js
+++ b/test/unit/services/fetch-personal-business-details-service.test.js
@@ -9,10 +9,6 @@ vi.mock('../../../src/dal/connector.js', () => ({
   getDalConnector: vi.fn(() => mockDalConnector)
 }))
 
-vi.mock('@defra/fcp-sfd-frontend-engine', () => ({
-  mappers: { mapPersonalBusinessDetails: mockMappedValue }
-}))
-
 // Test helpers
 const { getMappedData, getDalData } = await import('../../mocks/mock-personal-business-details.js')
 


### PR DESCRIPTION
Recently, the mappers have been removed from the individual services and put into the engine code. This broke the personalBusinessDetails mappers, and it isn't being called correctly.

This PR is to fix this.
