### PR TITLE
chore(#fls2-158): bump upstream-mock image tag

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
       WMP_ENDPOINT: ${WMP_ENDPOINT:-https://grants-ui.test.cdp-int.defra.cloud/woodland}
 
   upstream-mock:
-    image: defradigital/fcp-dal-upstream-mock:0.82.0
+    image: defradigital/fcp-dal-upstream-mock:0.88.0
     environment:
       MOCK_LOG_LEVEL: info
       MOCK_SERVER_COLLECTION: all


### PR DESCRIPTION
This follows the fix pushed to the upstream-mock