### PR TITLE
FLS2-127: Fix Missing Organisation Name on Business Details Address

### DIFF
--- a/src/dal/queries/business-details.js
+++ b/src/dal/queries/business-details.js
@@ -77,6 +77,7 @@ export const businessDetailsQueryWithoutCph = `
         type
       }
       address {
+        pafOrganisationName
         buildingNumberRange
         buildingName
         flatName


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-127

## Summary

When the CPH feature toggle is disabled (the default), the business details address was missing the first line — the organisation/building name (e.g. `UPPER CRUST`) — while the personal details page displayed it correctly.

The root cause was a missing `pafOrganisationName` field in `businessDetailsQueryWithoutCph`. The service selects this query when `CPH_ENABLED=false`, which is the default in all environments. Because the field was never requested from the DAL, it was never returned, and the `formatDisplayAddress` presenter silently dropped the `undefined` value via `.filter(Boolean)`.

The `businessDetailsQuery` (used when CPH is enabled) already included `pafOrganisationName`, as did the personal details query — making this an omission in the non-CPH variant only.

## Changes

- Add `pafOrganisationName` to the `address` selection set in `businessDetailsQueryWithoutCph` in `src/dal/queries/business-details.js`