### PR TITLE
Fix business schema address engine import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.5.0",
+        "@defra/fcp-sfd-frontend-engine": "0.6.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -509,9 +509,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.5.0.tgz",
-      "integrity": "sha512-oQKXvqYKijXv272WnpSVc4BrhnNZucHxHaLYvf1xRC+nHnor6GuElNBiI9Ul4iS4RSlsJKyShUlMG1AnAxvtvA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.6.0.tgz",
+      "integrity": "sha512-XmaOQnjBpfDcthrcZqQQuhDnvx14InZRgcRAf21K9H/HFKgTz9afbagcoaXl2NI/5uZwLSGKjpxA/HU7/46wcA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.5.0",
+    "@defra/fcp-sfd-frontend-engine": "0.6.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/routes/business/business-address-enter-routes.js
+++ b/src/routes/business/business-address-enter-routes.js
@@ -27,7 +27,7 @@ const postBusinessAddressEnter = {
   options: {
     auth: { scope: AMEND_PERMISSIONS },
     validate: {
-      payload: schemas.business.address,
+      payload: schemas.business.details.address,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const { yar, auth, payload } = request


### PR DESCRIPTION
This PR is fixing the business address engine import. `schemas.business.address` was removed from the engine and it is now instead `schemas.business.details.address `