### PR TITLE
chore: bump @defra/fcp-sfd-frontend-engine to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.6.0",
+        "@defra/fcp-sfd-frontend-engine": "0.7.0",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -509,9 +509,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.6.0.tgz",
-      "integrity": "sha512-XmaOQnjBpfDcthrcZqQQuhDnvx14InZRgcRAf21K9H/HFKgTz9afbagcoaXl2NI/5uZwLSGKjpxA/HU7/46wcA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.7.0.tgz",
+      "integrity": "sha512-bLa/6U2A24LP/wcYNaGKdatfIRQo1BBOSlq+9p1tnLyatTEZMgUJm6aZfGyymvw1XoWbSLT/xwuwNvo+OedB8Q==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.1"
@@ -1982,9 +1982,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2002,9 +1999,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2022,9 +2016,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2042,9 +2033,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2062,9 +2050,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2082,9 +2067,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5326,6 +5308,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.6.0",
+    "@defra/fcp-sfd-frontend-engine": "0.7.0",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",


### PR DESCRIPTION
## Summary

Bumps `@defra/fcp-sfd-frontend-engine` from 0.6.0 to 0.7.0.

## Changes
- Updated `package.json` and `package-lock.json` to engine 0.7.0.