### PR TITLE
Fix [object Object] on address check page after updating an address

### DIFF
--- a/src/presenters/business/business-address-check-presenter.js
+++ b/src/presenters/business/business-address-check-presenter.js
@@ -29,7 +29,7 @@ const businessAddressCheckPresenter = (businessDetails) => {
  *
  * When there is no pending change, the address falls back to the business address mapped
  * from the DAL. This has a nested `{ lookup, manual, ... }` shape, so it is formatted with
- * the shared `formatDisplayAddress` helper to avoid rendering `[object Object]`.
+ * the shared `formatDisplayAddress` helper.
  */
 const formatAddress = (changeBusinessAddress, address) => {
   if (!changeBusinessAddress) {

--- a/src/presenters/business/business-address-check-presenter.js
+++ b/src/presenters/business/business-address-check-presenter.js
@@ -3,6 +3,8 @@
  * @module businessAddressCheckPresenter
  */
 
+import { presenters } from '@defra/fcp-sfd-frontend-engine'
+
 const businessAddressCheckPresenter = (businessDetails) => {
   const { changeBusinessAddress, address, info, customer } = businessDetails
 
@@ -12,7 +14,7 @@ const businessAddressCheckPresenter = (businessDetails) => {
     pageTitle: 'Check your business address is correct before submitting',
     metaDescription: 'Check the address for your business is correct.',
     userName: customer.userName ?? null,
-    address: formatAddress(changeBusinessAddress ?? address),
+    address: formatAddress(changeBusinessAddress, address),
     businessName: info.businessName ?? null,
     sbi: info.sbi ?? null
   }
@@ -20,17 +22,27 @@ const businessAddressCheckPresenter = (businessDetails) => {
 
 /**
  * Formats the business address into an array of address parts.
- * - Removes falsy values (null, undefined, empty strings)
- * - When from postcode lookup, excludes `uprn`, `displayAddress` and `postcodeLookup` keys
+ *
+ * When the user has a pending change in the session (`changeBusinessAddress`) that flat
+ * address is used, removing falsy values and, for postcode lookup selections, the `uprn`,
+ * `displayAddress` and `postcodeLookup` keys.
+ *
+ * When there is no pending change, the address falls back to the business address mapped
+ * from the DAL. This has a nested `{ lookup, manual, ... }` shape, so it is formatted with
+ * the shared `formatDisplayAddress` helper to avoid rendering `[object Object]`.
  */
-const formatAddress = (businessAddress) => {
-  if (businessAddress.postcodeLookup) {
-    const { uprn, displayAddress, postcodeLookup, ...addressParts } = businessAddress
+const formatAddress = (changeBusinessAddress, address) => {
+  if (!changeBusinessAddress) {
+    return presenters.formatDisplayAddress(address)
+  }
+
+  if (changeBusinessAddress.postcodeLookup) {
+    const { uprn, displayAddress, postcodeLookup, ...addressParts } = changeBusinessAddress
 
     return Object.values(addressParts).filter(Boolean)
-  } else {
-    return Object.values(businessAddress).filter(Boolean)
   }
+
+  return Object.values(changeBusinessAddress).filter(Boolean)
 }
 
 const backLink = (postcodeLookup) => {

--- a/src/presenters/personal/personal-address-check-presenter.js
+++ b/src/presenters/personal/personal-address-check-presenter.js
@@ -27,7 +27,7 @@ const personalAddressCheckPresenter = (personalDetails) => {
  *
  * When there is no pending change, the address falls back to the personal address mapped
  * from the DAL. This has a nested `{ lookup, manual, ... }` shape, so it is formatted with
- * the shared `formatDisplayAddress` helper to avoid rendering `[object Object]`.
+ * the shared `formatDisplayAddress` helper.
  */
 const formatAddress = (changePersonalAddress, address) => {
   if (!changePersonalAddress) {

--- a/src/presenters/personal/personal-address-check-presenter.js
+++ b/src/presenters/personal/personal-address-check-presenter.js
@@ -3,6 +3,8 @@
  * @module personalAddressCheckPresenter
  */
 
+import { presenters } from '@defra/fcp-sfd-frontend-engine'
+
 const personalAddressCheckPresenter = (personalDetails) => {
   const { changePersonalAddress, address, info } = personalDetails
 
@@ -12,23 +14,33 @@ const personalAddressCheckPresenter = (personalDetails) => {
     pageTitle: 'Check your personal address is correct before submitting',
     metaDescription: 'Check the address for your personal account is correct.',
     userName: info.userName ?? null,
-    address: formatAddress(changePersonalAddress ?? address)
+    address: formatAddress(changePersonalAddress, address)
   }
 }
 
 /**
  * Formats the personal address into an array of address parts.
- * - Removes falsy values (null, undefined, empty strings)
- * - When from postcode lookup, excludes `uprn`, `displayAddress` and `postcodeLookup` keys
+ *
+ * When the user has a pending change in the session (`changePersonalAddress`) that flat
+ * address is used, removing falsy values and, for postcode lookup selections, the `uprn`,
+ * `displayAddress` and `postcodeLookup` keys.
+ *
+ * When there is no pending change, the address falls back to the personal address mapped
+ * from the DAL. This has a nested `{ lookup, manual, ... }` shape, so it is formatted with
+ * the shared `formatDisplayAddress` helper to avoid rendering `[object Object]`.
  */
-const formatAddress = (personalAddress) => {
-  if (personalAddress.postcodeLookup) {
-    const { uprn, displayAddress, postcodeLookup, ...addressParts } = personalAddress
+const formatAddress = (changePersonalAddress, address) => {
+  if (!changePersonalAddress) {
+    return presenters.formatDisplayAddress(address)
+  }
+
+  if (changePersonalAddress.postcodeLookup) {
+    const { uprn, displayAddress, postcodeLookup, ...addressParts } = changePersonalAddress
 
     return Object.values(addressParts).filter(Boolean)
-  } else {
-    return Object.values(personalAddress).filter(Boolean)
   }
+
+  return Object.values(changePersonalAddress).filter(Boolean)
 }
 
 const backLink = (postcodeLookup) => {

--- a/test/unit/presenters/business/business-address-check-presenter.test.js
+++ b/test/unit/presenters/business/business-address-check-presenter.test.js
@@ -17,10 +17,25 @@ describe('businessAddressCheckPresenter', () => {
         userName: 'Alfred Waldron'
       },
       address: {
-        address1: '10 Skirbeck Way',
-        address2: 'Lonely Lane',
+        lookup: {
+          pafOrganisationName: null,
+          buildingNumberRange: null,
+          flatName: null,
+          buildingName: null,
+          dependentLocality: null,
+          doubleDependentLocality: null,
+          street: null,
+          county: null,
+          uprn: null
+        },
+        manual: {
+          line1: '10 Skirbeck Way',
+          line2: 'Lonely Lane',
+          line3: null,
+          line4: 'Somerset',
+          line5: null
+        },
         city: 'Maidstone',
-        county: 'Somerset',
         postcode: 'SK22 1DL',
         country: 'United Kingdom'
       }
@@ -143,6 +158,56 @@ describe('businessAddressCheckPresenter', () => {
           'BA12 CBA',
           'United Kingdom'
         ])
+      })
+    })
+
+    describe('when there is no pending change in the session', () => {
+      describe('and the mapped business address was selected from the postcode lookup', () => {
+        beforeEach(() => {
+          data.address = {
+            lookup: {
+              pafOrganisationName: null,
+              buildingNumberRange: '18',
+              flatName: 'Flat 3',
+              buildingName: 'Fake Court',
+              dependentLocality: null,
+              doubleDependentLocality: null,
+              street: 'Maple Road',
+              county: 'Bristol',
+              uprn: '100000111111'
+            },
+            manual: {
+              line1: null,
+              line2: null,
+              line3: null,
+              line4: null,
+              line5: null
+            },
+            city: 'Westfield',
+            postcode: 'BS1 4AB',
+            country: 'United Kingdom'
+          }
+        })
+
+        test('it formats the nested DAL address as a flat array of strings', () => {
+          const result = businessAddressCheckPresenter(data)
+
+          expect(result.address).toEqual([
+            'Flat 3',
+            'Fake Court',
+            '18 Maple Road',
+            'Westfield',
+            'Bristol',
+            'BS1 4AB',
+            'United Kingdom'
+          ])
+        })
+
+        test('it does not render any address line as "[object Object]"', () => {
+          const result = businessAddressCheckPresenter(data)
+
+          expect(result.address.every((line) => typeof line === 'string')).toBe(true)
+        })
       })
     })
   })

--- a/test/unit/presenters/personal/personal-address-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-address-check-presenter.test.js
@@ -17,10 +17,25 @@ describe('personalAddressCheckPresenter', () => {
         }
       },
       address: {
-        address1: '10 Skirbeck Way',
-        address2: 'Lonely Lane',
+        lookup: {
+          pafOrganisationName: null,
+          buildingNumberRange: null,
+          flatName: null,
+          buildingName: null,
+          dependentLocality: null,
+          doubleDependentLocality: null,
+          street: null,
+          county: null,
+          uprn: null
+        },
+        manual: {
+          line1: '10 Skirbeck Way',
+          line2: 'Lonely Lane',
+          line3: null,
+          line4: 'Somerset',
+          line5: null
+        },
         city: 'Maidstone',
-        county: 'Somerset',
         postcode: 'SK22 1DL',
         country: 'United Kingdom'
       }
@@ -113,6 +128,56 @@ describe('personalAddressCheckPresenter', () => {
           'BA12 CBA',
           'United Kingdom'
         ])
+      })
+    })
+
+    describe('when there is no pending change in the session', () => {
+      describe('and the mapped personal address was selected from the postcode lookup', () => {
+        beforeEach(() => {
+          data.address = {
+            lookup: {
+              pafOrganisationName: null,
+              buildingNumberRange: '18',
+              flatName: 'Flat 3',
+              buildingName: 'Fake Court',
+              dependentLocality: null,
+              doubleDependentLocality: null,
+              street: 'Maple Road',
+              county: 'Bristol',
+              uprn: '100000111111'
+            },
+            manual: {
+              line1: null,
+              line2: null,
+              line3: null,
+              line4: null,
+              line5: null
+            },
+            city: 'Westfield',
+            postcode: 'BS1 4AB',
+            country: 'United Kingdom'
+          }
+        })
+
+        test('it formats the nested DAL address as a flat array of strings', () => {
+          const result = personalAddressCheckPresenter(data)
+
+          expect(result.address).toEqual([
+            'Flat 3',
+            'Fake Court',
+            '18 Maple Road',
+            'Westfield',
+            'Bristol',
+            'BS1 4AB',
+            'United Kingdom'
+          ])
+        })
+
+        test('it does not render any address line as "[object Object]"', () => {
+          const result = personalAddressCheckPresenter(data)
+
+          expect(result.address.every((line) => typeof line === 'string')).toBe(true)
+        })
       })
     })
   })

--- a/test/unit/routes/business/business-address-check-routes.test.js
+++ b/test/unit/routes/business/business-address-check-routes.test.js
@@ -101,10 +101,25 @@ describe('business address check', () => {
 const getMockData = () => {
   return {
     address: {
-      address1: '10 Skirbeck Way',
-      address2: '',
+      lookup: {
+        pafOrganisationName: null,
+        buildingNumberRange: null,
+        flatName: null,
+        buildingName: null,
+        dependentLocality: null,
+        doubleDependentLocality: null,
+        street: null,
+        county: null,
+        uprn: null
+      },
+      manual: {
+        line1: '10 Skirbeck Way',
+        line2: null,
+        line3: null,
+        line4: null,
+        line5: null
+      },
       city: 'Maidstone',
-      county: '',
       postcode: 'SK22 1DL',
       country: 'United Kingdom'
     },

--- a/test/unit/routes/personal/personal-address-check-routes.test.js
+++ b/test/unit/routes/personal/personal-address-check-routes.test.js
@@ -102,10 +102,25 @@ const getMockData = () => {
       }
     },
     address: {
-      address1: '10 Skirbeck Way',
-      address2: '',
+      lookup: {
+        pafOrganisationName: null,
+        buildingNumberRange: null,
+        flatName: null,
+        buildingName: null,
+        dependentLocality: null,
+        doubleDependentLocality: null,
+        street: null,
+        county: null,
+        uprn: null
+      },
+      manual: {
+        line1: '10 Skirbeck Way',
+        line2: null,
+        line3: null,
+        line4: null,
+        line5: null
+      },
       city: 'Maidstone',
-      county: '',
       postcode: 'SK22 1DL',
       country: 'United Kingdom'
     }


### PR DESCRIPTION
## Summary

On the business and personal **address check** pages, updating your address and then pressing the browser **Back** button showed `[object Object]` on the first two address lines instead of the real address.

## How to reproduce

1. Change your business (or personal) address via manual entry or postcode lookup.
2. Submit on the check page — the address saves successfully.
3. Press the browser **Back** button.
4. The check page shows:

```
[object Object]
[object Object]
CARDIFF
CF10 1EP
WALES
```

## Cause

The check presenter built the address with `Object.values(...)`, which assumes a flat object. On submit, the in-progress address is cleared from the session, so the page falls back to the address from the DAL — which is a nested `{ lookup, manual, ... }` object. Those two nested objects rendered as `[object Object]`. (The same happened when opening the check page without a pending change.)

## Fix

- The check presenters now format the fallback (DAL) address with the engine's existing `formatDisplayAddress` helper — the same one the details pages use — so it renders as proper address lines.
- Behaviour for in-progress (session) address changes is unchanged.
- Updated the presenter and route tests to use the real nested address shape (the old fixtures were flat, which hid the bug) and added a regression test asserting no line renders as `[object Object]`.

## Testing

- Affected presenter + route unit tests pass (34 tests).
- Lint clean.
