### PR TITLE
FLS2-171 Address select bug fix

### DIFF
--- a/src/presenters/business/business-address-select-presenter.js
+++ b/src/presenters/business/business-address-select-presenter.js
@@ -15,8 +15,8 @@ const businessAddressSelectPresenter = (data) => {
     userName: data.customer.userName ?? null,
     businessName: data.info.businessName ?? null,
     sbi: data.info.sbi ?? null,
-    postcode: data.changeBusinessPostcode.postcode,
-    displayAddresses: presenters.formatDisplayAddresses(data.changeBusinessAddresses, data.changeBusinessAddress)
+    postcode: data.changeBusinessPostcode?.postcode ?? null,
+    displayAddresses: presenters.formatDisplayAddresses(data.changeBusinessAddresses ?? [], data.changeBusinessAddress)
   }
 }
 

--- a/src/presenters/personal/personal-address-select-presenter.js
+++ b/src/presenters/personal/personal-address-select-presenter.js
@@ -13,8 +13,8 @@ const personalAddressSelectPresenter = (data) => {
     pageTitle: 'Choose your personal address',
     metaDescription: 'Choose the address for your personal account.',
     userName: data.info.userName ?? null,
-    postcode: data.changePersonalPostcode.postcode,
-    displayAddresses: presenters.formatDisplayAddresses(data.changePersonalAddresses, data.changePersonalAddress)
+    postcode: data.changePersonalPostcode?.postcode ?? null,
+    displayAddresses: presenters.formatDisplayAddresses(data.changePersonalAddresses ?? [], data.changePersonalAddress)
   }
 }
 

--- a/src/routes/business/business-address-select-routes.js
+++ b/src/routes/business/business-address-select-routes.js
@@ -15,7 +15,7 @@ const getBusinessAddressSelect = {
     const businessDetails = await fetchBusinessChangeService(yar, auth.credentials, ['changeBusinessPostcode', 'changeBusinessAddresses', 'changeBusinessAddress'])
 
     if (!businessDetails.changeBusinessPostcode || !businessDetails.changeBusinessAddresses) {
-      return h.redirect('/business-address-change')
+      return h.redirect('/business-details')
     }
 
     const pageData = businessAddressSelectPresenter(businessDetails)

--- a/src/routes/business/business-address-select-routes.js
+++ b/src/routes/business/business-address-select-routes.js
@@ -13,6 +13,11 @@ const getBusinessAddressSelect = {
   handler: async (request, h) => {
     const { yar, auth } = request
     const businessDetails = await fetchBusinessChangeService(yar, auth.credentials, ['changeBusinessPostcode', 'changeBusinessAddresses', 'changeBusinessAddress'])
+
+    if (!businessDetails.changeBusinessPostcode || !businessDetails.changeBusinessAddresses) {
+      return h.redirect('/business-address-change')
+    }
+
     const pageData = businessAddressSelectPresenter(businessDetails)
 
     return h.view('business/business-address-select', pageData)

--- a/src/routes/personal/personal-address-select-routes.js
+++ b/src/routes/personal/personal-address-select-routes.js
@@ -12,7 +12,7 @@ const getPersonalAddressSelect = {
     const personalDetails = await fetchPersonalChangeService(yar, auth.credentials, ['changePersonalPostcode', 'changePersonalAddresses', 'changePersonalAddress'])
 
     if (!personalDetails.changePersonalPostcode || !personalDetails.changePersonalAddresses) {
-      return h.redirect('/account-address-change')
+      return h.redirect('/personal-details')
     }
 
     const pageData = personalAddressSelectPresenter(personalDetails)

--- a/src/routes/personal/personal-address-select-routes.js
+++ b/src/routes/personal/personal-address-select-routes.js
@@ -10,6 +10,11 @@ const getPersonalAddressSelect = {
   handler: async (request, h) => {
     const { yar, auth } = request
     const personalDetails = await fetchPersonalChangeService(yar, auth.credentials, ['changePersonalPostcode', 'changePersonalAddresses', 'changePersonalAddress'])
+
+    if (!personalDetails.changePersonalPostcode || !personalDetails.changePersonalAddresses) {
+      return h.redirect('/account-address-change')
+    }
+
     const pageData = personalAddressSelectPresenter(personalDetails)
 
     return h.view('personal/personal-address-select', pageData)

--- a/test/unit/presenters/business/business-address-select-presenter.test.js
+++ b/test/unit/presenters/business/business-address-select-presenter.test.js
@@ -109,6 +109,20 @@ describe('businessAddressSelectPresenter', () => {
     })
   })
 
+  describe('the "postcode" property', () => {
+    describe('when the changeBusinessPostcode property is missing', () => {
+      beforeEach(() => {
+        delete data.changeBusinessPostcode
+      })
+
+      test('it should return postcode as null', () => {
+        const result = businessAddressSelectPresenter(data)
+
+        expect(result.postcode).toEqual(null)
+      })
+    })
+  })
+
   describe('the "displayAddresses" property', () => {
     describe('when provided with an additional address', () => {
       beforeEach(() => {
@@ -153,6 +167,24 @@ describe('businessAddressSelectPresenter', () => {
 
         expect(result.displayAddresses[0].selected).toBe(false)
         expect(result.displayAddresses[2].selected).toBe(true)
+      })
+    })
+
+    describe('when the changeBusinessAddresses property is missing', () => {
+      beforeEach(() => {
+        delete data.changeBusinessAddresses
+      })
+
+      test('it should return an empty display summary option', () => {
+        const result = businessAddressSelectPresenter(data)
+
+        expect(result.displayAddresses).toEqual([
+          {
+            value: 'display',
+            text: '0 addresses found',
+            selected: true
+          }
+        ])
       })
     })
   })

--- a/test/unit/presenters/personal/personal-address-select-presenter.test.js
+++ b/test/unit/presenters/personal/personal-address-select-presenter.test.js
@@ -79,6 +79,20 @@ describe('personalAddressSelectPresenter', () => {
     })
   })
 
+  describe('the "postcode" property', () => {
+    describe('when the changePersonalPostcode property is missing', () => {
+      beforeEach(() => {
+        delete data.changePersonalPostcode
+      })
+
+      test('it should return postcode as null', () => {
+        const result = personalAddressSelectPresenter(data)
+
+        expect(result.postcode).toEqual(null)
+      })
+    })
+  })
+
   describe('the "displayAddresses" property', () => {
     describe('when provided with an additional address', () => {
       beforeEach(() => {
@@ -123,6 +137,24 @@ describe('personalAddressSelectPresenter', () => {
 
         expect(result.displayAddresses[0].selected).toBe(false)
         expect(result.displayAddresses[2].selected).toBe(true)
+      })
+    })
+
+    describe('when the changePersonalAddresses property is missing', () => {
+      beforeEach(() => {
+        delete data.changePersonalAddresses
+      })
+
+      test('it should return an empty display summary option', () => {
+        const result = personalAddressSelectPresenter(data)
+
+        expect(result.displayAddresses).toEqual([
+          {
+            value: 'display',
+            text: '0 addresses found',
+            selected: true
+          }
+        ])
       })
     })
   })

--- a/test/unit/routes/business/business-address-select-routes.test.js
+++ b/test/unit/routes/business/business-address-select-routes.test.js
@@ -84,10 +84,10 @@ describe('business address select change', () => {
         fetchBusinessChangeService.mockResolvedValue({ ...getMockData(), changeBusinessPostcode: undefined })
       })
 
-      test('it redirects to /business-address-change', async () => {
+      test('it redirects to /business-details', async () => {
         await getBusinessAddressSelect.handler(request, h)
 
-        expect(h.redirect).toHaveBeenCalledWith('/business-address-change')
+        expect(h.redirect).toHaveBeenCalledWith('/business-details')
         expect(h.view).not.toHaveBeenCalled()
       })
     })
@@ -97,10 +97,10 @@ describe('business address select change', () => {
         fetchBusinessChangeService.mockResolvedValue({ ...getMockData(), changeBusinessAddresses: undefined })
       })
 
-      test('it redirects to /business-address-change', async () => {
+      test('it redirects to /business-details', async () => {
         await getBusinessAddressSelect.handler(request, h)
 
-        expect(h.redirect).toHaveBeenCalledWith('/business-address-change')
+        expect(h.redirect).toHaveBeenCalledWith('/business-details')
         expect(h.view).not.toHaveBeenCalled()
       })
     })

--- a/test/unit/routes/business/business-address-select-routes.test.js
+++ b/test/unit/routes/business/business-address-select-routes.test.js
@@ -78,6 +78,32 @@ describe('business address select change', () => {
         expect(h.view).toHaveBeenCalledWith('business/business-address-select', getPageData())
       })
     })
+
+    describe('when the postcode has not been set in session', () => {
+      beforeEach(() => {
+        fetchBusinessChangeService.mockResolvedValue({ ...getMockData(), changeBusinessPostcode: undefined })
+      })
+
+      test('it redirects to /business-address-change', async () => {
+        await getBusinessAddressSelect.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/business-address-change')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the addresses have not been set in session', () => {
+      beforeEach(() => {
+        fetchBusinessChangeService.mockResolvedValue({ ...getMockData(), changeBusinessAddresses: undefined })
+      })
+
+      test('it redirects to /business-address-change', async () => {
+        await getBusinessAddressSelect.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/business-address-change')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('POST /business-address-select', () => {

--- a/test/unit/routes/personal/personal-address-select-routes.test.js
+++ b/test/unit/routes/personal/personal-address-select-routes.test.js
@@ -73,6 +73,32 @@ describe('personal address select routes', () => {
         expect(h.view).toHaveBeenCalledWith('personal/personal-address-select', getPageData())
       })
     })
+
+    describe('when the postcode has not been set in session', () => {
+      beforeEach(() => {
+        fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalPostcode: undefined })
+      })
+
+      test('it redirects to /account-address-change', async () => {
+        await getPersonalAddressSelect.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/account-address-change')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the addresses have not been set in session', () => {
+      beforeEach(() => {
+        fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalAddresses: undefined })
+      })
+
+      test('it redirects to /account-address-change', async () => {
+        await getPersonalAddressSelect.handler(request, h)
+
+        expect(h.redirect).toHaveBeenCalledWith('/account-address-change')
+        expect(h.view).not.toHaveBeenCalled()
+      })
+    })
   })
 
   describe('POST /account-address-select', () => {

--- a/test/unit/routes/personal/personal-address-select-routes.test.js
+++ b/test/unit/routes/personal/personal-address-select-routes.test.js
@@ -79,10 +79,10 @@ describe('personal address select routes', () => {
         fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalPostcode: undefined })
       })
 
-      test('it redirects to /account-address-change', async () => {
+      test('it redirects to /personal-details', async () => {
         await getPersonalAddressSelect.handler(request, h)
 
-        expect(h.redirect).toHaveBeenCalledWith('/account-address-change')
+        expect(h.redirect).toHaveBeenCalledWith('/personal-details')
         expect(h.view).not.toHaveBeenCalled()
       })
     })
@@ -92,10 +92,10 @@ describe('personal address select routes', () => {
         fetchPersonalChangeService.mockResolvedValue({ ...getMockData(), changePersonalAddresses: undefined })
       })
 
-      test('it redirects to /account-address-change', async () => {
+      test('it redirects to /personal-details', async () => {
         await getPersonalAddressSelect.handler(request, h)
 
-        expect(h.redirect).toHaveBeenCalledWith('/account-address-change')
+        expect(h.redirect).toHaveBeenCalledWith('/personal-details')
         expect(h.view).not.toHaveBeenCalled()
       })
     })


### PR DESCRIPTION
## Summary

Fixes the "Sorry, there seems to be a problem with the service" error on `/business-address-select` and `/account-address-select` when these routes are reached without a postcode/address lookup already in session (e.g. direct navigation, bookmark, or refresh after session expiry).

## Root cause

The GET handlers passed data straight to their presenters, which dereferenced session-only fields (`changeBusinessPostcode`/`changeBusinessAddresses`, and personal equivalents) without checking they existed. If those keys were missing, `undefined.postcode` and `formatDisplayAddresses(undefined, ...)` threw a `TypeError`, caught by the global error handler and rendered as the generic error page.

## Changes

- **`business-address-select-routes.js`** / **`personal-address-select-routes.js`**: GET handlers now redirect to the corresponding details page (`/business-details`/ `/personal-details`) if the postcode or addresses aren't present in session, instead of rendering with missing data.
- **`business-address-select-presenter.js`** / **`personal-address-select-presenter.js`**: added defensive null-safety (`?.`, `?? []`) as a second layer of protection against missing session data.
- Added test coverage for the new redirect behaviour in both route test suites.