### PR TITLE
FLS2-180: Enforce VAT validation on the change page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@defra/fcp-sfd-frontend-engine": "0.9.0",
+        "@defra/fcp-sfd-frontend-engine": "0.9.1",
         "@defra/hapi-tracing": "1.30.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/bell": "13.1.0",
@@ -509,9 +509,9 @@
       "license": "MIT"
     },
     "node_modules/@defra/fcp-sfd-frontend-engine": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.9.0.tgz",
-      "integrity": "sha512-44HeftW9vxndE89QDLZtIdyf/3NaClAiK8JMmPUrpidoiEHV7svV4ZW5dMXyfqTxGFjqmotM06CixWjpEzoxOQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@defra/fcp-sfd-frontend-engine/-/fcp-sfd-frontend-engine-0.9.1.tgz",
+      "integrity": "sha512-vu1jNf79cUKNVeyT/FcfX4imyuS5LQE2cptkjgI7Fe1ZPZnLIIOaiWMSAKrdiEXa87fFczHCtoVr42DJJ08fXg==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "joi": "18.2.3"
@@ -5197,6 +5197,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@defra/fcp-sfd-frontend-engine": "0.9.0",
+    "@defra/fcp-sfd-frontend-engine": "0.9.1",
     "@defra/hapi-tracing": "1.30.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/bell": "13.1.0",

--- a/src/presenters/business/business-vat-change-presenter.js
+++ b/src/presenters/business/business-vat-change-presenter.js
@@ -1,6 +1,6 @@
 /**
- * Formats data ready for presenting in the `/business-VAT-registration-number-change` page
- * @module businessVatEnterPresenter
+ * Formats data ready for presenting in the `/business-vat-registration-number-change` page
+ * @module businessVatChangePresenter
  */
 
 const businessVatChangePresenter = (data, payload) => {

--- a/src/routes/business/business-vat-change-routes.js
+++ b/src/routes/business/business-vat-change-routes.js
@@ -25,7 +25,7 @@ const postBusinessVatChange = {
   options: {
     auth: { scope: FULL_PERMISSIONS },
     validate: {
-      payload: schemas.business.details.vat,
+      payload: schemas.business.vat.change,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const { yar, auth, payload } = request

--- a/src/routes/business/business-vat-remove-routes.js
+++ b/src/routes/business/business-vat-remove-routes.js
@@ -25,7 +25,7 @@ const postBusinessVatRemove = {
   options: {
     auth: { scope: FULL_PERMISSIONS },
     validate: {
-      payload: schemas.business.vatRemove,
+      payload: schemas.business.vat.remove,
       options: { abortEarly: false },
       failAction: async (request, h, err) => {
         const errors = utils.formatValidationErrors(err.details || [])


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-180

## Summary

On `/business-vat-registration-number-change` a user could leave the VAT field empty, click Continue, and proceed through to submit with no validation error — the journey silently completed as if it had succeeded even though nothing was saved. This affected both the "change existing VAT" and "add new VAT" scenarios. The root cause was that the change route validated against `schemas.business.details.vat`, the optional business-details schema that allows an empty string. This PR points the route at the new required schema so an empty or malformed VAT number is rejected.

## Changes

- `business-vat-change-routes.js`: validate the POST payload against `schemas.business.vat.change` (required, 9-digit) instead of `schemas.business.details.vat` (which allowed an empty string).
- `business-vat-remove-routes.js`: use `schemas.business.vat.remove`, following the engine's grouping of the standalone VAT action schemas.
- `business-vat-change-presenter.js`: correct the `@module` name (`businessVatEnterPresenter` → `businessVatChangePresenter`) and the route casing in the JSDoc comment.

## Behaviour

- Submitting an empty or invalid VAT number on the change page now re-renders the page with an error summary and the field error "Enter a VAT registration number" (HTTP 400) and blocks progression. A valid 9-digit number proceeds to the check page as before.

## Notes

- Requires `@defra/fcp-sfd-frontend-engine@0.9.1` (paired PR in DEFRA/fcp-sfd-frontend-engine), which introduces `schemas.business.vat.change` and `schemas.business.vat.remove`.
