### PR TITLE
Refactor Date Of Birth Logic

### DIFF
--- a/src/presenters/personal/personal-dob-check-presenter.js
+++ b/src/presenters/personal/personal-dob-check-presenter.js
@@ -6,11 +6,7 @@
 import { presenters } from '@defra/fcp-sfd-frontend-engine'
 
 const personalDobCheckPresenter = (personalDetails) => {
-  const { day, month, year } = personalDetails.changePersonalDob ?? personalDetails.info.dateOfBirth
-  // new Date() needs the format YYYY-MM-DD with leading zeros e.g. '1990-04-05' not '1990-4-5'
-  const personalDob = new Date(
-    `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
-  )
+  const dob = personalDetails.changePersonalDob ?? personalDetails.info.dateOfBirth
 
   return {
     backLink: { href: '/account-date-of-birth-change' },
@@ -18,7 +14,7 @@ const personalDobCheckPresenter = (personalDetails) => {
     metaDescription: 'Check the date of birth for your personal account is correct.',
     userName: personalDetails.info.userName ?? null,
     changeLink: '/account-date-of-birth-change',
-    dateOfBirth: presenters.formatLongDate(personalDob)
+    dateOfBirth: presenters.formatLongDateFromParts(dob)
   }
 }
 

--- a/src/services/personal/update-personal-dob-change-service.js
+++ b/src/services/personal/update-personal-dob-change-service.js
@@ -9,7 +9,8 @@
  * @module updatePersonalDobChangeService
  */
 
-import { mutations } from '@defra/fcp-sfd-frontend-engine'
+import { constants, mutations, utils } from '@defra/fcp-sfd-frontend-engine'
+
 import { fetchPersonalChangeService } from './fetch-personal-change-service.js'
 import { flashNotification } from '../../utils/notifications/flash-notification.js'
 import { updateDalService } from '../DAL/update-dal-service.js'
@@ -21,21 +22,13 @@ const updatePersonalDobChangeService = async (yar, credentials) => {
     return
   }
 
-  const { day, month, year } = personalDetails.changePersonalDob
-
-  const variables = {
-    input: {
-      // DAL expects dateOfBirth as YYYY-MM-DD e.g. '1990-04-05' not '1990-4-5'
-      dateOfBirth: `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
-      crn: personalDetails.crn
-    }
-  }
+  const variables = utils.buildUpdatePersonalDobVariables(personalDetails.changePersonalDob, personalDetails.crn)
 
   await updateDalService(mutations.updateCustomerDob, variables, credentials.sessionId)
 
   yar.clear('personalDetailsUpdate')
 
-  flashNotification(yar, 'Success', 'You have updated your date of birth')
+  flashNotification(yar, 'Success', constants.successMessages.PERSONAL_DATE_OF_BIRTH)
 }
 
 export {

--- a/test/unit/presenters/personal/personal-dob-check-presenter.test.js
+++ b/test/unit/presenters/personal/personal-dob-check-presenter.test.js
@@ -98,5 +98,13 @@ describe('personalDobCheckPresenter', () => {
 
       expect(result.dateOfBirth).toBeNull()
     })
+
+    test('it returns null if date of birth on record is missing', () => {
+      delete data.info.dateOfBirth
+
+      const result = personalDobCheckPresenter(data)
+
+      expect(result.dateOfBirth).toBeNull()
+    })
   })
 })

--- a/test/unit/services/personal/update-personal-dob-change-service.test.js
+++ b/test/unit/services/personal/update-personal-dob-change-service.test.js
@@ -2,7 +2,7 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest'
 
 // Things we need to mock
-import { mutations } from '@defra/fcp-sfd-frontend-engine'
+import { constants, mutations } from '@defra/fcp-sfd-frontend-engine'
 import { fetchPersonalChangeService } from '../../../../src/services/personal/fetch-personal-change-service.js'
 import { flashNotification } from '../../../../src/utils/notifications/flash-notification.js'
 import { updateDalService } from '../../../../src/services/DAL/update-dal-service.js'
@@ -77,7 +77,7 @@ describe('updatePersonalDobChangeService', () => {
     test('adds a flash notification confirming the change in data', async () => {
       await updatePersonalDobChangeService(yar, credentials)
 
-      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', 'You have updated your date of birth')
+      expect(flashNotification).toHaveBeenCalledWith(yar, 'Success', constants.successMessages.PERSONAL_DATE_OF_BIRTH)
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-55

## Summary

Removes the inline date-of-birth mutation-variable construction and hard-coded success message from the personal DOB update service, consuming the shared engine logic instead. No behaviour change — the built variables and success message are identical.

## Changes

- `update-personal-dob-change-service.js` now uses `utils.buildUpdatePersonalDobVariables(...)` and
  `constants.successMessages.PERSONAL_DATE_OF_BIRTH` in place of the inline padding block and literal string.
- Update the service unit test to assert against `constants.successMessages.PERSONAL_DATE_OF_BIRTH`.

## Notes

- Depends on engine `0.23.0` (`buildUpdatePersonalDobVariables`, `PERSONAL_DATE_OF_BIRTH`). **Blocked until the engine is published**, after which the `@defra/fcp-sfd-frontend-engine` pin must be bumped `0.22.1` → `0.23.0` and the lockfile refreshed.