### PR TITLE
Fix personal address selection bug

### DIFF
--- a/src/views/personal/personal-address-select.njk
+++ b/src/views/personal/personal-address-select.njk
@@ -41,7 +41,10 @@
             label: {
               html: '<div class="govuk-label govuk-!-font-weight-bold">Select an address</div>'
             },
-            items: displayAddresses
+            items: displayAddresses,
+            errorMessage: errors.addresses and {
+              text: errors.addresses.text
+            }
           }) }}
         </fieldset>
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FLS2-197

During testing for the internal personal address pages a bug was identified in the address select page where the gov component wasn't displaying any errors correctly. This issue has been found in the frontend external now as well. This PR fixes this.